### PR TITLE
Add README and Google Colab links for Accelerated Python User Guide

### DIFF
--- a/Accelerated_Python_User_Guide/notebooks/README.md
+++ b/Accelerated_Python_User_Guide/notebooks/README.md
@@ -1,0 +1,16 @@
+# Accelerated Python User Guide
+
+## Notebooks
+
+| Notebook      | Link |
+| ----------- | ----------- |
+| Chapter 1: GPU Computing Basics | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_1_GPU_Computing_Basics.ipynb)|
+| Chapter 2: Brief Intro to CUDA | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_2_Brief_Intro_to_CUDA.ipynb)|
+| Chapter 3: Python on the GPU | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_3_Python_on_the_GPU.ipynb)|
+| Chapter 4: Scientific Computing with CuPy | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_4_Scientific_Computing_with_CuPy.ipynb)|
+| Chapter 5: CUDA Kernels with Numba | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_5_CUDA_Kernels_with_Numba.ipynb)|
+| Chapter 6: Intro to cuDF | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_6_Intro_to_cuDF.ipynb)|
+| Chapter 7: Intro to cuML | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_7_Intro_to_cuML.ipynb)|
+| Chapter 8: Intro to cuGraph | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_8_Intro_to_cuGraph.ipynb)|
+| Chapter 9: Developer Tools | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_9_Developer_Tools.ipynb)|
+| Chapter X: Distributed Computing cuNumeric | [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/accelerated-computing-hub/blob/main/Accelerated_Python_User_Guide/notebooks/Chapter_X_Distributed_Computing_cuNumeric.ipynb)|


### PR DESCRIPTION
I've created a README for the Accelerated Python User Guide, and have added a table to access the notebooks in Google Colab with 1 click via Buttons. 
Many folks tend to use Google Colab and a direct link will significantly improve the user experience.

I've confirmed that all links are functioning.