### PR TITLE
Use ``from_map`` over ``from_delayed``

### DIFF
--- a/gpu-python-tutorial/8.0_Multi-GPU_with_Dask.ipynb
+++ b/gpu-python-tutorial/8.0_Multi-GPU_with_Dask.ipynb
@@ -22,7 +22,8 @@
    "source": [
     "!git clone https://github.com/rapidsai/rapidsai-csp-utils.git\n",
     "!python rapidsai-csp-utils/colab/pip-install.py"
-   ]
+   ],
+   "id": "b4cb704672ac4ce4"
   },
   {
    "cell_type": "markdown",
@@ -261,11 +262,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@dask.delayed\n",
     "def gen_partition():\n",
     "    return cudf.datasets.timeseries()\n",
     "\n",
-    "gddf = dask_cudf.from_delayed([gen_partition() for i in range(30)])\n",
+    "gddf = dask_cudf.from_map(gen_partition, list(range(30)))\n",
     "gddf"
    ]
   },


### PR DESCRIPTION
We've started moving users away from ``from_delayed`` a while ago since ``from_map`` has significantly better integration into the query optimiser.

See [here](https://docs.dask.org/en/stable/generated/dask_expr.from_delayed.html#dask_expr.from_delayed) for docs