### PR TITLE
[CUDA Python and CUDA C++ Tutorial]: Change the default Google Colab instance to a T4 GPU instance

### DIFF
--- a/gpu-cpp-tutorial/notebooks/01.01-Introduction/01.01.01-CUDA-Made-Easy.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.01-Introduction/01.01.01-CUDA-Made-Easy.ipynb
@@ -105,6 +105,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.02-Execution-Spaces/01.02.01-Execution-Spaces.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.02-Execution-Spaces/01.02.01-Execution-Spaces.ipynb
@@ -337,6 +337,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.02-Execution-Spaces/01.02.02-Exercise-Annotate-Execution-Spaces.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.02-Execution-Spaces/01.02.02-Exercise-Annotate-Execution-Spaces.ipynb
@@ -132,6 +132,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.02-Execution-Spaces/01.02.03-Exercise-Changing-Execution-Space.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.02-Execution-Spaces/01.02.03-Exercise-Changing-Execution-Space.ipynb
@@ -121,6 +121,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.02-Execution-Spaces/01.02.04-Exercise-Compute-Median-Temperature.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.02-Execution-Spaces/01.02.04-Exercise-Compute-Median-Temperature.ipynb
@@ -168,6 +168,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.03-Extending-Algorithms/01.03.01-Extending-Algorithms.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.03-Extending-Algorithms/01.03.01-Extending-Algorithms.ipynb
@@ -809,6 +809,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.03-Extending-Algorithms/01.03.02-Exercise-Computing-Variance.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.03-Extending-Algorithms/01.03.02-Exercise-Computing-Variance.ipynb
@@ -178,6 +178,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.04-Vocabulary-Types/01.04.01-Vocabulary-Types.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.04-Vocabulary-Types/01.04.01-Vocabulary-Types.ipynb
@@ -338,6 +338,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.04-Vocabulary-Types/01.04.02-Exercise-mdspan.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.04-Vocabulary-Types/01.04.02-Exercise-mdspan.ipynb
@@ -212,6 +212,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.05-Serial-vs-Parallel/01.05.01-Serial-vs-Parallel.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.05-Serial-vs-Parallel/01.05.01-Serial-vs-Parallel.ipynb
@@ -283,6 +283,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.05-Serial-vs-Parallel/01.05.02-Exercise-Segmented-Sum-Optimization.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.05-Serial-vs-Parallel/01.05.02-Exercise-Segmented-Sum-Optimization.ipynb
@@ -193,6 +193,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.05-Serial-vs-Parallel/01.05.03-Exercise-Segmented-Mean.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.05-Serial-vs-Parallel/01.05.03-Exercise-Segmented-Mean.ipynb
@@ -248,6 +248,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.06-Memory-Spaces/01.06.01-Memory-Spaces.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.06-Memory-Spaces/01.06.01-Memory-Spaces.ipynb
@@ -188,6 +188,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.06-Memory-Spaces/01.06.02-Exercise-Copy.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.06-Memory-Spaces/01.06.02-Exercise-Copy.ipynb
@@ -190,6 +190,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.07-Summary/01.07.01-Summary.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.07-Summary/01.07.01-Summary.ipynb
@@ -51,6 +51,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-cpp-tutorial/notebooks/01.08-Advanced/01.08.01-Advanced.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.08-Advanced/01.08.01-Advanced.ipynb
@@ -186,6 +186,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-cpp-tutorial/notebooks/02.01-Introduction/02.01.01-Introduction.ipynb
+++ b/gpu-cpp-tutorial/notebooks/02.01-Introduction/02.01.01-Introduction.ipynb
@@ -71,6 +71,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-cpp-tutorial/notebooks/02.02-Asynchrony/02.02.01-Asynchrony.ipynb
+++ b/gpu-cpp-tutorial/notebooks/02.02-Asynchrony/02.02.01-Asynchrony.ipynb
@@ -331,6 +331,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/02.02-Asynchrony/02.02.02-Exercise-Compute-IO-Overlap.ipynb
+++ b/gpu-cpp-tutorial/notebooks/02.02-Asynchrony/02.02.02-Exercise-Compute-IO-Overlap.ipynb
@@ -240,6 +240,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/02.02-Asynchrony/02.02.03-Exercise-Nsight.ipynb
+++ b/gpu-cpp-tutorial/notebooks/02.02-Asynchrony/02.02.03-Exercise-Nsight.ipynb
@@ -123,6 +123,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/02.02-Asynchrony/02.02.04-Exercise-NVTX.ipynb
+++ b/gpu-cpp-tutorial/notebooks/02.02-Asynchrony/02.02.04-Exercise-NVTX.ipynb
@@ -194,6 +194,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/02.03-Streams/02.03.01-Streams.ipynb
+++ b/gpu-cpp-tutorial/notebooks/02.03-Streams/02.03.01-Streams.ipynb
@@ -264,6 +264,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/02.03-Streams/02.03.02-Exercise-Async-Copy.ipynb
+++ b/gpu-cpp-tutorial/notebooks/02.03-Streams/02.03.02-Exercise-Async-Copy.ipynb
@@ -220,6 +220,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/02.04-Pinned-Memory/02.04.01-Pinned.ipynb
+++ b/gpu-cpp-tutorial/notebooks/02.04-Pinned-Memory/02.04.01-Pinned.ipynb
@@ -133,6 +133,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/02.04-Pinned-Memory/02.04.02-Exercise-Copy-Overlap.ipynb
+++ b/gpu-cpp-tutorial/notebooks/02.04-Pinned-Memory/02.04.02-Exercise-Copy-Overlap.ipynb
@@ -228,6 +228,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.01-Introduction/03.01-Introduction.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.01-Introduction/03.01-Introduction.ipynb
@@ -67,6 +67,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.02-Kernels/03.02.01-Kernels.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.02-Kernels/03.02.01-Kernels.ipynb
@@ -462,6 +462,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.02-Kernels/03.02.02-Exercise-Symmetry.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.02-Kernels/03.02.02-Exercise-Symmetry.ipynb
@@ -208,6 +208,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.02-Kernels/03.02.03-Exercise-Row-Symmetry.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.02-Kernels/03.02.03-Exercise-Row-Symmetry.ipynb
@@ -209,6 +209,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.02-Kernels/03.02.04-Dev-Tools.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.02-Kernels/03.02.04-Dev-Tools.ipynb
@@ -126,6 +126,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.03-Atomics/03.03.01-Histogram.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.03-Atomics/03.03.01-Histogram.ipynb
@@ -223,6 +223,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.03-Atomics/03.03.02-Exercise-Fix-Histogram.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.03-Atomics/03.03.02-Exercise-Fix-Histogram.ipynb
@@ -196,6 +196,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.04-Synchronization/03.04.01-Sync.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.04-Synchronization/03.04.01-Sync.ipynb
@@ -237,6 +237,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.04-Synchronization/03.04.02-Exercise-Histogram.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.04-Synchronization/03.04.02-Exercise-Histogram.ipynb
@@ -217,6 +217,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.05-Shared-Memory/03.05.01-Shared.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.05-Shared-Memory/03.05.01-Shared.ipynb
@@ -140,6 +140,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.05-Shared-Memory/03.05.02-Exercise-Optimize-Histogram.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.05-Shared-Memory/03.05.02-Exercise-Optimize-Histogram.ipynb
@@ -216,6 +216,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.06-Cooperative-Algorithms/03.06.01-Cooperative.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.06-Cooperative-Algorithms/03.06.01-Cooperative.ipynb
@@ -201,6 +201,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-cpp-tutorial/notebooks/03.06-Cooperative-Algorithms/03.06.02-Exercise-Cooperative-Histogram.ipynb
+++ b/gpu-cpp-tutorial/notebooks/03.06-Cooperative-Algorithms/03.06.02-Exercise-Cooperative-Histogram.ipynb
@@ -213,6 +213,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",

--- a/gpu-python-tutorial/0.0_Welcome.ipynb
+++ b/gpu-python-tutorial/0.0_Welcome.ipynb
@@ -65,6 +65,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/1.0_CPU_GPU_Comparison.ipynb
+++ b/gpu-python-tutorial/1.0_CPU_GPU_Comparison.ipynb
@@ -122,6 +122,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/2.0_Numba.ipynb
+++ b/gpu-python-tutorial/2.0_Numba.ipynb
@@ -520,6 +520,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/2.1_Numba_lab.ipynb
+++ b/gpu-python-tutorial/2.1_Numba_lab.ipynb
@@ -143,6 +143,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/2.2_Numba_lab_solution.ipynb
+++ b/gpu-python-tutorial/2.2_Numba_lab_solution.ipynb
@@ -164,6 +164,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/3.0_Numba_gauss.ipynb
+++ b/gpu-python-tutorial/3.0_Numba_gauss.ipynb
@@ -287,6 +287,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/3.1_Numba_lab_2.ipynb
+++ b/gpu-python-tutorial/3.1_Numba_lab_2.ipynb
@@ -161,6 +161,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/3.2_Numba_lab_2_solution.ipynb
+++ b/gpu-python-tutorial/3.2_Numba_lab_2_solution.ipynb
@@ -175,6 +175,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/4.0_pyNVML.ipynb
+++ b/gpu-python-tutorial/4.0_pyNVML.ipynb
@@ -159,6 +159,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/4.1_CUDA_Array_Interface.ipynb
+++ b/gpu-python-tutorial/4.1_CUDA_Array_Interface.ipynb
@@ -123,6 +123,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/5.0_Cupy.ipynb
+++ b/gpu-python-tutorial/5.0_Cupy.ipynb
@@ -271,6 +271,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/5.1_Cupy_Lab.ipynb
+++ b/gpu-python-tutorial/5.1_Cupy_Lab.ipynb
@@ -193,6 +193,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/5.2_Cupy_Lab_solution.ipynb
+++ b/gpu-python-tutorial/5.2_Cupy_Lab_solution.ipynb
@@ -191,6 +191,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/5.3_Cupy_nvmath.ipynb
+++ b/gpu-python-tutorial/5.3_Cupy_nvmath.ipynb
@@ -448,6 +448,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/6.0_cuDF.ipynb
+++ b/gpu-python-tutorial/6.0_cuDF.ipynb
@@ -390,6 +390,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/7.0_cuML.ipynb
+++ b/gpu-python-tutorial/7.0_cuML.ipynb
@@ -177,6 +177,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/gpu-python-tutorial/8.0_Multi-GPU_with_Dask.ipynb
+++ b/gpu-python-tutorial/8.0_Multi-GPU_with_Dask.ipynb
@@ -378,6 +378,13 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+    "gpuType": "T4",
+    "provenance": [],
+    "toc_visible": true
+  },
+
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",


### PR DESCRIPTION
Our notebooks need a GPU instance. This changes them so that when opened in Google Colab, a T4 GPU instance is used without the user having to select it.

Sometimes T4 instances aren't available due to demand, so we still need to add code to check whether we've got the right kind of instance. 

Partially addresses #56.