### PR TITLE
Minor fixes to C++ tutorial on readthrough

### DIFF
--- a/gpu-cpp-tutorial/notebooks/01.08-Advanced/01.08.01-Advanced.ipynb
+++ b/gpu-cpp-tutorial/notebooks/01.08-Advanced/01.08.01-Advanced.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile Sources/host-function-pointers.cpp\n",
+    "%%writefile Sources/host-function-pointers.cu\n",
     "#include <thrust/transform.h>\n",
     "#include <thrust/universal_vector.h>\n",
     "#include <cstdio>\n",
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile Sources/host-function-pointers-fix.cpp\n",
+    "%%writefile Sources/host-function-pointers-fix.cu\n",
     "#include <thrust/transform.h>\n",
     "#include <thrust/universal_vector.h>\n",
     "#include <cstdio>\n",
@@ -128,8 +128,8 @@
     "But as we just learned, taking address of `__device__` function is not allowed on the host.\n",
     "\n",
     "That should shed some light on why the version with lambda works.\n",
-    "Lambda is not a function, it's a function object.\n",
-    "Code below illustrates what lambda actually looks like:"
+    "A lambda is not a function, it's a function object.\n",
+    "The code below illustrates what lambda actually looks like:"
    ]
   },
   {
@@ -138,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile Sources/function-objects.cpp\n",
+    "%%writefile Sources/function-objects.cu\n",
     "\n",
     "#include <thrust/execution_policy.h>\n",
     "#include <thrust/universal_vector.h>\n",


### PR DESCRIPTION
### 01-08
- Match source file name with writefile magic.
- Minor grammar fix.
