### PR TITLE
Fix numba timings with cuda.syncronize

### DIFF
--- a/gpu-python-tutorial/2.0_Numba.ipynb
+++ b/gpu-python-tutorial/2.0_Numba.ipynb
@@ -457,7 +457,8 @@
    "outputs": [],
    "source": [
     "%%timeit -n 100\n",
-    "foo[blocks, threads](gpu_random_array, gpu_output)"
+    "foo[blocks, threads](gpu_random_array, gpu_output)\n",
+    "cuda.synchronize()  # Wait for the kernel to compute as it will be done lazily"
    ]
   },
   {
@@ -524,11 +525,10 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-    "gpuType": "T4",
-    "provenance": [],
-    "toc_visible": true
+   "gpuType": "T4",
+   "provenance": [],
+   "toc_visible": true
   },
-
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",


### PR DESCRIPTION
@seberg noticed that this notebook incorrectly measures the speed of this numba kernel call. This PR adds a `cuda.synchronize()` to fix it, the point being made still stands so no further refactoring is required as a result.