### PR TITLE
Add link to CuPy notebook 03

### DIFF
--- a/tutorials/accelerated-python/notebooks/syllabi/pyhpc__numpy_cupy_mpi4py__4_hours.ipynb
+++ b/tutorials/accelerated-python/notebooks/syllabi/pyhpc__numpy_cupy_mpi4py__4_hours.ipynb
@@ -12,6 +12,7 @@
     "| # | Topic | Solution | Technologies | \n",
     "|---|-------|----------|--------------|\n",
     "| 01 | [NumPy Intro - ndarray Basics](../fundamentals/01__numpy_intro__ndarray_basics.ipynb) | [Click](../fundamentals/solutions/01__numpy_intro__ndarray_basics__SOLUTION.ipynb) | NumPy |\n",
+    "| 03 | [NumPy to CuPy - ndarray Basics](../fundamentals/03__numpy_to_cupy__ndarray_basics.ipynb) | [Click](../fundamentals/solutions/03__numpy_to_cupy__ndarray_basics__SOLUTION.ipynb) | CuPy |\n",
     "| 05 | [Memory Spaces - Power Iteration](../fundamentals/05__memory_spaces__power_iteration.ipynb) | [Click](../fundamentals/solutions/05__memory_spaces__power_iteration__SOLUTION.ipynb) | CuPy |\n",
     "| 06 | [Asynchrony - Power Iteration](../fundamentals/06__asynchrony__power_iteration.ipynb) | [Click](../fundamentals/solutions/06__asynchrony__power_iteration__SOLUTION.ipynb) | CuPy |\n",
     "| 60 | [mpi4py](../distributed/60__mpi4py.ipynb) | - | mpi4py |\n",


### PR DESCRIPTION
@brycelelbach: I think we forgot to add a link to notebook 03: CuPy Basics to the syllabus.  