### PR TITLE
Update 60__mpi4py.ipynb

### DIFF
--- a/tutorials/accelerated-python/notebooks/distributed/60__mpi4py.ipynb
+++ b/tutorials/accelerated-python/notebooks/distributed/60__mpi4py.ipynb
@@ -9,7 +9,7 @@
    },
    "outputs": [],
    "source": [
-    " MPIRUN=\"mpirun --oversubscribe\"\n",
+    "MPIRUN=\"mpirun --oversubscribe\"\n",
     "\n",
     "import os\n",
     "\n",


### PR DESCRIPTION
Removes white space before `MPIRUN` definition in first cell:

```diff
-  MPIRUN=mpirun --oversubscribe
+ MPIRUN=mpirun --oversubscribe
```