### PR TITLE
CI: Ignore docs.rapids.ai in Lychee link checker.

### DIFF
--- a/brev/.lycheeignore
+++ b/brev/.lycheeignore
@@ -11,3 +11,6 @@ https://opendata.cityofnewyork.us/overview/#termsofuse
 
 # Medium.com - returns 403 for automated requests but works in browsers
 https://medium.com/.*
+
+# RAPIDS documentation - has aggressive bot protection that resets connections
+https://docs.rapids.ai/.*


### PR DESCRIPTION
The RAPIDS documentation site has aggressive bot protection that intermittently resets connections, causing flaky CI failures in the link checker.