### PR TITLE
Docs: Fix broken CCCL documentation links.

### DIFF
--- a/Accelerated_Python_User_Guide/notebooks/Chapter_cuda.cccl.parallel.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_cuda.cccl.parallel.ipynb
@@ -2994,7 +2994,7 @@
    "metadata": {},
    "source": [
     "## Resources\n",
-    "API Reference: https://nvidia.github.io/cccl/python/parallel_api.html#module-cuda.compute.algorithms"
+    "API Reference: https://nvidia.github.io/cccl/unstable/python/compute_api.html#module-cuda.compute.algorithms"
    ]
   }
  ],

--- a/tutorials/accelerated-python/notebooks/kernels/41__kernel_authoring__book_histogram.ipynb
+++ b/tutorials/accelerated-python/notebooks/kernels/41__kernel_authoring__book_histogram.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "## 1. Environment Setup & Data Download\n",
     "\n",
-    "Let's learn to use some advanced CUDA features like shared memory, atomics, and [cuda.cooperative](https://nvidia.github.io/cccl/python/cooperative.html) to write an efficient histogram kernel to determine the most frequent characters in a collection of books.\n",
+    "Let's learn to use some advanced CUDA features like shared memory, atomics, and [cuda.cooperative](https://nvidia.github.io/cccl/unstable/python/coop.html) to write an efficient histogram kernel to determine the most frequent characters in a collection of books.\n",
     "\n",
     "First, let's download our dataset and install the necessary tools."
    ]
@@ -249,7 +249,7 @@
     "\n",
     "Looking at the profile trace, it seems like our code is quite slow - look at the memory workload tab and see how low the throughput is!\n",
     "\n",
-    "One improvement we should make is to separate loading values from the histogram update and to perform striped loads (also known as coalesced access). We'll use [cuda.cooperative](https://nvidia.github.io/cccl/python/cooperative.html)'s block load instead of writing this by hand.\n",
+    "One improvement we should make is to separate loading values from the histogram update and to perform striped loads (also known as coalesced access). We'll use [cuda.cooperative](https://nvidia.github.io/cccl/unstable/python/coop.html)'s block load instead of writing this by hand.\n",
     "\n",
     "**TODO: Rewrite the code below to use `cuda.cooperative` to load from `values` into local memory.**\n",
     "- **Create a `coop.block.load(dtype, threads_per_block, items_per_thread, algorithm)` object outside of the kernel.**\n",

--- a/tutorials/accelerated-python/notebooks/kernels/solutions/41__kernel_authoring__book_histogram__SOLUTION.ipynb
+++ b/tutorials/accelerated-python/notebooks/kernels/solutions/41__kernel_authoring__book_histogram__SOLUTION.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "## Exercise - Kernel Authoring - Book Histogram - SOLUTION\n",
     "\n",
-    "Let's learn to use some advanced CUDA features like shared memory, atomics, and [cuda.cooperative](https://nvidia.github.io/cccl/python/cooperative.html) to write an efficient histogram kernel to determine the most frequent characters in a collection of books.\n",
+    "Let's learn to use some advanced CUDA features like shared memory, atomics, and [cuda.cooperative](https://nvidia.github.io/cccl/unstable/python/coop.html) to write an efficient histogram kernel to determine the most frequent characters in a collection of books.\n",
     "\n",
     "First, let's download our dataset."
    ]
@@ -428,7 +428,7 @@
     "id": "e1f72831-780f-4cf5-8ff1-2092ecb193d9"
    },
    "source": [
-    "We improved the code by separating loading from values from the histogram update and to perform striped loads using [cuda.cooperative](https://nvidia.github.io/cccl/python/cooperative.html)'s block load instead of doing the I/O by hand.\n",
+    "We improved the code by separating loading from values from the histogram update and to perform striped loads using [cuda.cooperative](https://nvidia.github.io/cccl/unstable/python/coop.html)'s block load instead of doing the I/O by hand.\n",
     "\n",
     "While that helps a bit, our code still has major issues. It's taking thousand of cycles to issue a single operation!\n",
     "\n",

--- a/tutorials/accelerated-python/notebooks/libraries/23__cuda_cccl__customizing_algorithms.ipynb
+++ b/tutorials/accelerated-python/notebooks/libraries/23__cuda_cccl__customizing_algorithms.ipynb
@@ -63,7 +63,7 @@
       "id": "98385a37-45b5-4b42-8a30-22112d2292df",
       "metadata": {},
       "source": [
-        "The [CUDA Core Compute Libraries (CCCL)](https://nvidia.github.io/cccl/python/) provide high-quality, high-performance abstractions for CUDA development in Python. The `cuda-cccl` Python package is composed of two indepdendent subpackages:\n",
+        "The [CUDA Core Compute Libraries (CCCL)](https://nvidia.github.io/cccl/unstable/python/) provide high-quality, high-performance abstractions for CUDA development in Python. The `cuda-cccl` Python package is composed of two indepdendent subpackages:\n",
         "\n",
         "* `cuda.compute` is a **parallel algorithms library** containing algorithms like `reduce`, `transform`, `scan` and `sort`. These  can be combined to implement more complex algorithms, while delivering the performance of hand-optimized CUDA kernels, portable across different GPU architectures. They are general-purpose and **designed to be used with CuPy, PyTorch and other array/tensor frameworks.**.\n",
         "\n",
@@ -1381,7 +1381,7 @@
       "id": "13f16d8f-76e9-40d6-b9ed-159c68379d02",
       "metadata": {},
       "source": [
-        "In this example, you'll implement the running average of a sequence, using a single call to the [inclusive_scan](https://nvidia.github.io/cccl/python/parallel_api.html#cuda.compute.algorithms.inclusive_scan) API. To do this, you'll have to piece together many of the concepts we've learned about so far."
+        "In this example, you'll implement the running average of a sequence, using a single call to the [inclusive_scan](https://nvidia.github.io/cccl/unstable/python/compute_api.html#cuda.compute.algorithms.inclusive_scan) API. To do this, you'll have to piece together many of the concepts we've learned about so far."
       ]
     },
     {
@@ -1445,8 +1445,8 @@
       "source": [
         "## Resources\n",
         "\n",
-        "* `cuda-cccl` Documentation: https://nvidia.github.io/cccl/python/\n",
-        "* `parallel` API Reference: https://nvidia.github.io/cccl/python/parallel_api.html#cuda-cccl-parallel-api-reference"
+        "* `cuda-cccl` Documentation: https://nvidia.github.io/cccl/unstable/python/\n",
+        "* `parallel` API Reference: https://nvidia.github.io/cccl/unstable/python/compute_api.html#cuda-compute-api-reference"
       ]
     }
   ],

--- a/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/01.04.01-Vocabulary-Types.ipynb
+++ b/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/01.04.01-Vocabulary-Types.ipynb
@@ -208,7 +208,7 @@
     "\n",
     "`std::make_pair` is a host function, not a device function.  Thinking back to the earlier part of our course, a host function is compiled to run on the host, and if there is no equivalent device function, that code will NOT run on the device.  That is what the error message is telling us, i.e., we don't have any device function called `std::make_pair` and therefore it can't run on the device.\n",
     "\n",
-    "Fortunately NVIDIA has implemented many of these standard types in CUDA via the [libcu++](https://nvidia.github.io/cccl/libcudacxx/) library, and for the `std::` types implemented in `libcu++`, it's as simple as prepending `cuda::` in front of the `std::` types you're using.\n",
+    "Fortunately NVIDIA has implemented many of these standard types in CUDA via the [libcu++](https://nvidia.github.io/cccl/unstable/libcudacxx/) library, and for the `std::` types implemented in `libcu++`, it's as simple as prepending `cuda::` in front of the `std::` types you're using.\n",
     "\n",
     "Notice below the code is identical to the previous example, with the two small changes of prepending `cuda::` in front of both `std::pair` and `std::make_pair`.\n",
     "\n",

--- a/tutorials/cuda-cpp/notebooks/02.02-Asynchrony/02.02.01-Asynchrony.ipynb
+++ b/tutorials/cuda-cpp/notebooks/02.02-Asynchrony/02.02.01-Asynchrony.ipynb
@@ -85,7 +85,7 @@
     "While the GPU is computing the next simulation step, the CPU can be writing out the previous results to disk.\n",
     "This overlap uses both CPU and GPU resources efficiently, reducing the total runtime.\n",
     "Unfortunately, Thrust’s interface doesn’t provide a direct way to separate launching GPU work from waiting for its completion.\n",
-    "Under the hood, Thrust calls another library called [CUB (CUDA UnBound)](https://nvidia.github.io/cccl/cub/) to implement its GPU algorithms.  If you look at the software stack, you'll see CUB us underneath Thrust.  CUB is also a library in it's own right.\n",
+    "Under the hood, Thrust calls another library called [CUB (CUDA UnBound)](https://nvidia.github.io/cccl/unstable/cub/) to implement its GPU algorithms.  If you look at the software stack, you'll see CUB us underneath Thrust.  CUB is also a library in it's own right.\n",
     "\n"
    ]
   },

--- a/tutorials/cuda-cpp/notebooks/03.06-Cooperative-Algorithms/03.06.02-Exercise-Cooperative-Histogram.ipynb
+++ b/tutorials/cuda-cpp/notebooks/03.06-Cooperative-Algorithms/03.06.02-Exercise-Cooperative-Histogram.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## Exercise: Coarsening\n",
     "\n",
-    "To compute the [block histogram using CUB](https://nvidia.github.io/cccl/cub/api/classcub_1_1BlockHistogram.html), follow these four steps:\n",
+    "To compute the [block histogram using CUB](https://nvidia.github.io/cccl/unstable/cub/api/classcub_1_1BlockHistogram.html), follow these four steps:\n",
     "\n",
     "1. Declare the histogram parameters as compile time variable: the block size, number of bins, and elements per thread:\n",
     "\n",


### PR DESCRIPTION
The CCCL docs at nvidia.github.io/cccl/ were restructured to use versioned URLs with an `/unstable/` prefix, and some pages were renamed. This PR updates all 10 broken links across 7 notebooks.

**Changes:**
- `/cccl/python/` → `/cccl/unstable/python/`
- `/cccl/cub/` → `/cccl/unstable/cub/`
- `/cccl/libcudacxx/` → `/cccl/unstable/libcudacxx/`
- `parallel_api.html` → `compute_api.html`
- `cooperative.html` → `coop.html`
- `#cuda-cccl-parallel-api-reference` → `#cuda-compute-api-reference`

**Files modified:**
- `Accelerated_Python_User_Guide/notebooks/Chapter_cuda.cccl.parallel.ipynb`
- `tutorials/accelerated-python/notebooks/libraries/23__cuda_cccl__customizing_algorithms.ipynb`
- `tutorials/accelerated-python/notebooks/kernels/41__kernel_authoring__book_histogram.ipynb`
- `tutorials/accelerated-python/notebooks/kernels/solutions/41__kernel_authoring__book_histogram__SOLUTION.ipynb`
- `tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/01.04.01-Vocabulary-Types.ipynb`
- `tutorials/cuda-cpp/notebooks/02.02-Asynchrony/02.02.01-Asynchrony.ipynb`
- `tutorials/cuda-cpp/notebooks/03.06-Cooperative-Algorithms/03.06.02-Exercise-Cooperative-Histogram.ipynb`

Verified with `brev/test-links.bash .` — all 1065 links pass (986 OK, 0 errors).