### PR TITLE
Tutorials: Update Nsight Streamer to 2026.1.1

### DIFF
--- a/tutorials/accelerated-python/brev/docker-compose.yml
+++ b/tutorials/accelerated-python/brev/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - "127.0.0.1:8888:8888" # JupyterLab
   nsight:
     <<: [*gpu-config, *common-service, *persistent-service]
-    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2025.3.1
+    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2026.1.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
       - "127.0.0.1:8080:8080" # HTTP

--- a/tutorials/cuda-cpp/brev/docker-compose.yml
+++ b/tutorials/cuda-cpp/brev/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - "127.0.0.1:8888:8888" # JupyterLab
   nsight:
     <<: [*gpu-config, *common-service, *persistent-service]
-    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2025.3.1
+    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2026.1.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
       - "127.0.0.1:8080:8080" # HTTP

--- a/tutorials/cuda-tile/brev/docker-compose.yml
+++ b/tutorials/cuda-tile/brev/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - "127.0.0.1:8888:8888" # JupyterLab
   nsight:
     <<: [*gpu-config, *common-service, *persistent-service]
-    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2025.3.1
+    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2026.1.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
       - "127.0.0.1:8080:8080" # HTTP

--- a/tutorials/nvmath-python/brev/docker-compose.yml
+++ b/tutorials/nvmath-python/brev/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - "127.0.0.1:8888:8888" # JupyterLab
   nsight:
     <<: [*gpu-config, *common-service, *persistent-service]
-    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2025.3.1
+    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2026.1.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
       - "127.0.0.1:8080:8080" # HTTP

--- a/tutorials/stdpar/brev/docker-compose.yml
+++ b/tutorials/stdpar/brev/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - "127.0.0.1:8888:8888" # JupyterLab
   nsight:
     <<: [*gpu-config, *common-service, *persistent-service]
-    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2025.3.1
+    image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2026.1.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
       - "127.0.0.1:8080:8080" # HTTP


### PR DESCRIPTION
Update the Nsight Streamer NSys image from `2025.3.1` to `2026.1.1` across all tutorial docker-compose files:

- `tutorials/accelerated-python/brev/docker-compose.yml`
- `tutorials/cuda-cpp/brev/docker-compose.yml`
- `tutorials/cuda-tile/brev/docker-compose.yml`
- `tutorials/nvmath-python/brev/docker-compose.yml`
- `tutorials/stdpar/brev/docker-compose.yml`