### PR TITLE
Tutorials/CUDA C++: Rebase on to CUDA 13.1 container

### DIFF
--- a/.github/workflows/mirror-base-images.yml
+++ b/.github/workflows/mirror-base-images.yml
@@ -21,10 +21,6 @@ jobs:
     strategy:
       matrix:
         image:
-          - source: rapidsai/devcontainers:25.08-cpp-cuda12.8
-            target_name: rapidsai-devcontainers-25.08-cpp-cuda12.8
-          - source: rapidsai/devcontainers:25.10-cpp-cuda12.9
-            target_name: rapidsai-devcontainers-25.10-cpp-cuda12.9
           - source: pytorch/pytorch:2.9.0-cuda12.8-cudnn9-runtime
             target_name: pytorch-2.9.0-cuda12.8-cudnn9-runtime
           - source: nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu22.04

--- a/tutorials/cuda-cpp/brev/dockerfile
+++ b/tutorials/cuda-cpp/brev/dockerfile
@@ -1,43 +1,54 @@
-FROM ghcr.io/nvidia/mirrors/rapidsai-devcontainers-25.10-cpp-cuda12.9
+FROM ghcr.io/nvidia/mirrors/nvidia-cuda-13.1.0-devel-ubuntu22.04
 
 ENV ACH_TUTORIAL=cuda-cpp \
-    ACH_NSYS_PATH=/usr/local/cuda-12.9/bin/nsys \
-    ACH_NCU_PATH=/usr/local/cuda-12.9/bin/ncu \
-    PATH=/accelerated-computing-hub/brev/wrappers:${PATH} \
+    PYTHON_VERSION=3.12 \
+    ACH_NSYS_PATH=/usr/local/cuda/bin/nsys \
+    ACH_NCU_PATH=/usr/local/cuda/bin/ncu \
     PIP_ROOT_USER_ACTION=ignore \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
     CUPY_CACHE_DIR=/tmp/cupy_cache \
-    MPLCONFIGDIR=/tmp/matplotlib_cache
+    MPLCONFIGDIR=/tmp/matplotlib_cache \
+    VIRTUAL_ENV_DISABLE_PROMPT=1 \
+    PATH=/accelerated-computing-hub/brev/wrappers:/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 
-# Copy only requirements.txt first for better Docker layer caching.
-COPY tutorials/${ACH_TUTORIAL}/brev/requirements.txt /opt/requirements.txt
-
-RUN set -ex \
- && `# Install Python packages` \
-     && pip install --no-cache-dir --root-user-action=ignore -r /opt/requirements.txt \
-     && rm -f /opt/requirements.txt \
- && `# Install system packages` \
-     && apt-get update -y \
-     && apt-get install -y --no-install-recommends ffmpeg git-lfs gosu sudo \
-     && apt-get clean -y \
-     && rm -rf /var/lib/apt/lists/*
-
-# Disable unnecessary default Jupyter extensions.
-RUN python -m jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \
- && python -m jupyter labextension disable "@jupyterlab/console-extension:tracker"
-
-# Enable passwordless sudo for all users and pass through environment and path
-RUN echo 'ALL ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
- && sed -i -e 's/^Defaults\s*env_reset/Defaults !env_reset/' -e 's/^Defaults\s*secure_path=/#&/' /etc/sudoers
-
-# Install Docker
+# Install system packages (needed before pip install for git-based packages)
 RUN apt-get update -y \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    git \
+    git-lfs \
     apt-transport-https \
     ca-certificates \
     curl \
     gnupg \
     lsb-release \
- && mkdir -p /etc/apt/keyrings \
+    gosu \
+    libglib2.0-0 \
+    sudo \
+    ffmpeg \
+ && apt-get clean -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# Enable passwordless sudo for all users and pass through environment and path
+RUN echo 'ALL ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+ && sed -i -e 's/^Defaults\s*env_reset/Defaults !env_reset/' -e 's/^Defaults\s*secure_path=/#&/' /etc/sudoers
+
+# Install Python
+RUN curl -fsSL https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0xBA6932366A755776 | gpg --dearmor -o /usr/share/keyrings/deadsnakes.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/deadsnakes.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ppa.list \
+ && apt-get update -y \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-dev \
+    python${PYTHON_VERSION}-venv \
+ && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
+ && ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 \
+ && ln -sf /usr/bin/python3 /usr/bin/python \
+ && ln -s /usr/local/bin/pip /usr/bin/pip \
+ && rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Docker
+RUN mkdir -p /etc/apt/keyrings \
  && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
  && apt-get update -y \
@@ -49,6 +60,17 @@ RUN apt-get update -y \
     docker-compose-plugin \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/*
+
+# Copy only requirements.txt first for better Docker layer caching.
+COPY tutorials/${ACH_TUTORIAL}/brev/requirements.txt /opt/requirements.txt
+
+# Install Python packages.
+RUN pip install --no-cache-dir --root-user-action=ignore -r /opt/requirements.txt \
+ && rm -f /opt/requirements.txt
+
+# Disable unnecessary default Jupyter extensions.
+RUN python -m jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \
+ && python -m jupyter labextension disable "@jupyterlab/console-extension:tracker"
 
 COPY --chmod=0777 . /accelerated-computing-hub
 

--- a/tutorials/cuda-cpp/brev/test.bash
+++ b/tutorials/cuda-cpp/brev/test.bash
@@ -9,6 +9,8 @@
 
 TUTORIAL_ROOT=/accelerated-computing-hub/tutorials/cuda-cpp
 
+START_TIME=$(date +%s.%N)
+
 nvidia-smi
 
 if [ $# -gt 0 ]; then
@@ -21,3 +23,16 @@ if [ $# -gt 0 ]; then
     fi
     exit $?
 fi
+
+END_TIME=$(date +%s.%N)
+ELAPSED=$(awk "BEGIN {print $END_TIME - $START_TIME}")
+
+echo ""
+awk -v elapsed="$ELAPSED" 'BEGIN {
+    hours = int(elapsed / 3600)
+    minutes = int((elapsed % 3600) / 60)
+    seconds = elapsed % 60
+    printf "Elapsed time: %dh %dm %.3fs\n", hours, minutes, seconds
+}'
+
+exit 0


### PR DESCRIPTION
Rebase the CUDA C++ tutorial from `rapidsai-devcontainers-25.10-cpp-cuda12.9` to the `nvidia-cuda-13.1.0-devel-ubuntu22.04` base image (CUDA 13.1), and modernize the setup to match the accelerated-python tutorial.

### Changes

**`tutorials/cuda-cpp/brev/dockerfile`**
- Base image: `rapidsai-devcontainers-25.10-cpp-cuda12.9` → `nvidia-cuda-13.1.0-devel-ubuntu22.04`
- Install Python 3.12 from deadsnakes PPA (base image no longer bundles Python)
- Structured ENV block with `PIP_DISABLE_PIP_VERSION_CHECK`, `VIRTUAL_ENV_DISABLE_PROMPT`, updated `PATH`
- System packages installed with `DEBIAN_FRONTEND=noninteractive` and comprehensive package list
- Passwordless sudo setup matching accelerated-python
- Docker installation cleaned up
- Use Nsight tools from the CUDA toolkit (`/usr/local/cuda/bin/nsys`, `/usr/local/cuda/bin/ncu`)
- Jupyter announcements disabled
- Clean layer ordering: system packages → sudo → Python → Docker → pip → Jupyter config → COPY

**`tutorials/cuda-cpp/brev/docker-compose.yml`**
- No functional changes (kept existing configuration)

**`tutorials/cuda-cpp/brev/requirements.txt`**
- Added explicit `jupyterlab` dependency

**`tutorials/cuda-cpp/brev/test.bash`**
- Added elapsed time reporting