### PR TITLE
Tutorials/Accelerated Python: Install cuDF and cuML in the main environment

### DIFF
--- a/brev/test-notebook-format.py
+++ b/brev/test-notebook-format.py
@@ -17,9 +17,8 @@ metadata policy.  Canonical format means:
     the required ``name`` field).
   - nbformat 4, nbformat_minor 5.
 
-The cuDF kernelspec is accepted as an alternative to the default ipykernel.
-If a notebook has any other kernelspec (or none), --fix replaces it with the
-default.
+If a notebook has any non-standard kernelspec (or none), --fix replaces it
+with the default.
 
 Usage:
   ./brev/test-notebook-format.py                       # check all tutorials
@@ -77,12 +76,6 @@ STANDARD_METADATA = {
 STANDARD_NBFORMAT = 4
 STANDARD_NBFORMAT_MINOR = 5
 
-CUDF_KERNELSPEC = {
-    "display_name": "Python 3 (RAPIDS 25.10)",
-    "language": "python",
-    "name": "cudf-cu13-25.10",
-}
-
 # ANSI colors
 RED = "\033[0;31m"
 GREEN = "\033[0;32m"
@@ -92,23 +85,6 @@ NC = "\033[0m"  # No Color
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def has_cudf_kernelspec(metadata) -> bool:
-    """Check if a notebook's metadata contains the cuDF kernelspec."""
-    ks = metadata.get("kernelspec", {})
-    return (
-        ks.get("display_name") == CUDF_KERNELSPEC["display_name"]
-        and ks.get("language") == CUDF_KERNELSPEC["language"]
-        and ks.get("name") == CUDF_KERNELSPEC["name"]
-    )
-
-
-def get_expected_metadata(metadata) -> dict:
-    expected = dict(STANDARD_METADATA)
-    if has_cudf_kernelspec(metadata):
-        expected["kernelspec"] = dict(CUDF_KERNELSPEC)
-    return expected
 
 
 def is_solution_notebook(notebook_path: Path) -> bool:
@@ -171,7 +147,7 @@ def canonicalize_notebook(notebook_path: Path) -> tuple[str, list[str]]:
 
     # -- Detect original metadata problems before nbformat.read() -----------
     actual_metadata = raw.get("metadata", {})
-    expected_metadata = get_expected_metadata(actual_metadata)
+    expected_metadata = dict(STANDARD_METADATA)
     metadata_diffs = diff_metadata(actual_metadata, expected_metadata, "metadata")
     if metadata_diffs:
         problems.extend(metadata_diffs)
@@ -315,14 +291,12 @@ def check_notebook(notebook_path: Path, fix: bool) -> bool:
     with open(notebook_path, "r", encoding="utf-8") as f:
         original_text = f.read()
 
-    tag = "cudf" if has_cudf_kernelspec(json.loads(original_text).get("metadata", {})) else "standard"
-
     if original_text == canonical_text:
-        print(f"{GREEN}✓{NC} {notebook_path} ({tag})")
+        print(f"{GREEN}✓{NC} {notebook_path}")
         return True
 
     # There are problems
-    print(f"{RED}✗{NC} {notebook_path} ({tag})")
+    print(f"{RED}✗{NC} {notebook_path}")
     for p in problems:
         print(p)
 

--- a/tutorials/accelerated-python/brev/dockerfile
+++ b/tutorials/accelerated-python/brev/dockerfile
@@ -6,7 +6,6 @@ ENV ACH_TUTORIAL=accelerated-python \
     NSIGHT_SYSTEMS_DEB_FILE=2026_1/NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb \
     NSIGHT_COMPUTE_VERSION=2025.4.1 \
     NSIGHT_COMPUTE_DEB_FILE=debian12/x86_64/nsight-compute-2025.4.1_2025.4.1.2-1_amd64.deb \
-    ACH_RAPIDS_VENV=/opt/venvs/rapids \
     OMPI_ALLOW_RUN_AS_ROOT=1 \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
     PIP_ROOT_USER_ACTION=ignore \
@@ -67,6 +66,15 @@ COPY tutorials/${ACH_TUTORIAL}/brev/requirements.txt /opt/requirements.txt
 RUN pip install --no-cache-dir --root-user-action=ignore -r /opt/requirements.txt \
  && rm -f /opt/requirements.txt
 
+# Upgrade numba-cuda and cuda-cccl to the versions needed by the tutorial
+# notebooks. cuDF and cuML's published metadata still declares
+# numba-cuda<0.23, but they work fine with newer numba-cuda at runtime, so
+# we bypass the declared constraint with --no-deps --force-reinstall.
+RUN pip install --no-cache-dir --root-user-action=ignore \
+    --no-deps --force-reinstall \
+    "numba-cuda[cu13] == 0.28.2" \
+    "cuda-cccl[test-cu13] == 0.4.5"
+
 # Install MPI.
 RUN apt-get update -y \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -89,20 +97,6 @@ RUN curl -L -O https://developer.nvidia.com/downloads/assets/tools/secure/nsight
 # Disable unnecessary default Jupyter extensions.
 RUN python -m jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \
  && python -m jupyter labextension disable "@jupyterlab/console-extension:tracker"
-
-# Create an isolated Python env with cuDF and cuML, and register it as a Jupyter kernel.
-RUN python -m venv ${ACH_RAPIDS_VENV} \
- && ${ACH_RAPIDS_VENV}/bin/pip install --no-cache-dir \
-    --extra-index-url=https://pypi.nvidia.com \
-    "cudf-cu13==25.10.*" \
-    "cuml-cu13==25.10.*" \
-    "scikit-learn>=1.5,<1.6" \
-    ipykernel \
-    pytest \
- && ${ACH_RAPIDS_VENV}/bin/python -m ipykernel install \
-    --name=cudf-cu13-25.10 \
-    --display-name="Python 3 (RAPIDS 25.10)" \
-    --prefix=/usr/local
 
 COPY --chmod=0777 . /accelerated-computing-hub
 

--- a/tutorials/accelerated-python/brev/requirements.txt
+++ b/tutorials/accelerated-python/brev/requirements.txt
@@ -1,5 +1,5 @@
 # Arrays
-numpy == 2.4.2
+numpy == 2.2.6
 
 # Scientific/numeric
 scipy == 1.17.1
@@ -18,10 +18,13 @@ jupyterlab-execute-time == 3.3.0
 
 # CUDA
 cuda-python == 13.1.1
-numba-cuda[cu13] == 0.28.2
 nvmath-python[cu13] == 0.8.0
 cupy-cuda13x == 13.6.0
-cuda-cccl[test-cu13] == 0.4.5
+cuda-cccl == 0.4.5
+
+# RAPIDS
+cudf-cu13 == 26.2.1
+cuml-cu13 == 26.2.0
 
 # NVIDIA developer tools
 nvtx == 0.2.14

--- a/tutorials/accelerated-python/brev/test.bash
+++ b/tutorials/accelerated-python/brev/test.bash
@@ -2,8 +2,8 @@
 #
 # Run tests for the accelerated-python tutorial.
 #
-# When called with no arguments, runs all three test suites (packages, RAPIDS,
-# notebooks).  When called with arguments:
+# When called with no arguments, runs both test suites (packages, notebooks).
+# When called with arguments:
 #   - Bare words (e.g. "03") are treated as a pytest -k filter for notebook tests.
 #   - Paths or flags (e.g. "test/test_packages.py", "-k foo") are forwarded to
 #     pytest directly.
@@ -31,16 +31,10 @@ if [ $# -gt 0 ]; then
     fi
     EXIT_CODE=$?
 else
-    # Run regular package tests.
-    echo "Running regular package tests..."
-    pytest "${TUTORIAL_ROOT}/test/test_packages.py"
+    # Run package tests.
+    echo "Running package tests..."
+    pytest "${TUTORIAL_ROOT}/test/test_packages.py" "${TUTORIAL_ROOT}/test/test_rapids.py"
     EXIT_CODE_PACKAGES=$?
-
-    # Run RAPIDS tests.
-    echo ""
-    echo "Running RAPIDS package tests in virtual environment..."
-    /opt/venvs/rapids/bin/pytest "${TUTORIAL_ROOT}/test/test_rapids.py"
-    EXIT_CODE_RAPIDS=$?
 
     # Test solution notebooks.
     echo ""
@@ -49,7 +43,7 @@ else
     EXIT_CODE_NOTEBOOKS=$?
 
     # Overall exit code is non-zero if any test suite failed.
-    EXIT_CODE=$((EXIT_CODE_PACKAGES || EXIT_CODE_RAPIDS || EXIT_CODE_NOTEBOOKS))
+    EXIT_CODE=$((EXIT_CODE_PACKAGES || EXIT_CODE_NOTEBOOKS))
 fi
 
 END_TIME=$(date +%s.%N)

--- a/tutorials/accelerated-python/notebooks/libraries/20__cudf__nyc_parking_violations.ipynb
+++ b/tutorials/accelerated-python/notebooks/libraries/20__cudf__nyc_parking_violations.ipynb
@@ -694,9 +694,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (RAPIDS 25.10)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "cudf-cu13-25.10"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/accelerated-python/notebooks/libraries/21__cudf_pandas__nyc_parking_violations.ipynb
+++ b/tutorials/accelerated-python/notebooks/libraries/21__cudf_pandas__nyc_parking_violations.ipynb
@@ -268,9 +268,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (RAPIDS 25.10)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "cudf-cu13-25.10"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/accelerated-python/notebooks/libraries/22__cuml.ipynb
+++ b/tutorials/accelerated-python/notebooks/libraries/22__cuml.ipynb
@@ -182,9 +182,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (RAPIDS 25.10)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "cudf-cu13-25.10"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/accelerated-python/notebooks/libraries/solutions/20__cudf__nyc_parking_violations__SOLUTION.ipynb
+++ b/tutorials/accelerated-python/notebooks/libraries/solutions/20__cudf__nyc_parking_violations__SOLUTION.ipynb
@@ -1655,9 +1655,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (RAPIDS 25.10)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "cudf-cu13-25.10"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/accelerated-python/notebooks/libraries/solutions/21__cudf_pandas__nyc_parking_violations__SOLUTION.ipynb
+++ b/tutorials/accelerated-python/notebooks/libraries/solutions/21__cudf_pandas__nyc_parking_violations__SOLUTION.ipynb
@@ -67,9 +67,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (RAPIDS 25.10)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "cudf-cu13-25.10"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/accelerated-python/test/test_rapids.py
+++ b/tutorials/accelerated-python/test/test_rapids.py
@@ -1,7 +1,6 @@
 """
 RAPIDS tests for accelerated-python tutorial.
 These tests validate that cuDF and cuML are installed and functional.
-These tests should be run in the RAPIDS venv.
 """
 
 import pytest


### PR DESCRIPTION
## Summary
- Removes the separate RAPIDS Python venv and its Jupyter kernel registration from the accelerated-python Dockerfile, reducing container size by eliminating a duplicate Python environment with ipykernel/pytest.
- Installs `cudf-cu13==26.2.1` and `cuml-cu13==26.2.0` directly in the main environment via `requirements.txt`, now that the numba-cuda compatibility issue is resolved.
- Switches all 5 notebooks that used the `Python 3 (RAPIDS 25.10)` kernel to the standard `python3` kernel, and runs RAPIDS tests with regular pytest instead of the venv pytest.
- Removes RAPIDS kernelspec handling from `test-notebook-format.py` so it no longer accepts or mentions the RAPIDS kernel as an alternative.