### PR TITLE
Brev: Remove unused Docker-in-Docker to reduce image size.

### DIFF
--- a/tutorials/accelerated-python/brev/dockerfile
+++ b/tutorials/accelerated-python/brev/dockerfile
@@ -55,20 +55,6 @@ RUN curl -fsSL https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0xBA693236
  && rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED \
  && rm -rf /var/lib/apt/lists/*
 
-# Install Docker
-RUN mkdir -p /etc/apt/keyrings \
- && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
- && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
- && apt-get update -y \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    docker-buildx-plugin \
-    docker-compose-plugin \
- && apt-get clean -y \
- && rm -rf /var/lib/apt/lists/*
-
 # Install PyTorch with CUDA 13.0 support.
 RUN pip install --no-cache-dir --root-user-action=ignore \
     --index-url https://download.pytorch.org/whl/cu130 \

--- a/tutorials/cuda-cpp/brev/dockerfile
+++ b/tutorials/cuda-cpp/brev/dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update -y \
     ca-certificates \
     curl \
     gnupg \
-    lsb-release \
     gosu \
     libglib2.0-0 \
     sudo \
@@ -45,20 +44,6 @@ RUN curl -fsSL https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0xBA693236
  && ln -sf /usr/bin/python3 /usr/bin/python \
  && ln -s /usr/local/bin/pip /usr/bin/pip \
  && rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED \
- && rm -rf /var/lib/apt/lists/*
-
-# Install Docker
-RUN mkdir -p /etc/apt/keyrings \
- && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
- && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
- && apt-get update -y \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    docker-buildx-plugin \
-    docker-compose-plugin \
- && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Copy only requirements.txt first for better Docker layer caching.

--- a/tutorials/nvmath-python/brev/dockerfile
+++ b/tutorials/nvmath-python/brev/dockerfile
@@ -26,27 +26,6 @@ RUN python -m jupyter labextension disable "@jupyterlab/apputils-extension:annou
 RUN echo 'ALL ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
  && sed -i -e 's/^Defaults\s*env_reset/Defaults !env_reset/' -e 's/^Defaults\s*secure_path=/#&/' /etc/sudoers
 
-# Install Docker
-RUN apt-get update -y \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release \
- && mkdir -p /etc/apt/keyrings \
- && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
- && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
- && apt-get update -y \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    docker-buildx-plugin \
-    docker-compose-plugin \
- && apt-get clean -y \
- && rm -rf /var/lib/apt/lists/*
-
 COPY --chmod=0777 . /accelerated-computing-hub
 
 WORKDIR /accelerated-computing-hub/tutorials/${ACH_TUTORIAL}/notebooks


### PR DESCRIPTION
## Summary

- Remove Docker-in-Docker installation from the `accelerated-python`, `cuda-cpp`, and `nvmath-python` Brev dockerfiles.
- Docker was unused inside these containers and removing it reduces image size.

```
$ brev/test-docker-image-sizes.bash compare --owner nvidia
 --tutorial accelerated-python --tag pull-request-156-latest --baseline main-latest
========================================
Image: ghcr.io/nvidia/accelerated-python-tutorial
========================================
  Current    (pull-request-156-latest)                12.53 GB
  Baseline   (main-latest)                            12.66 GB
  ────────────────────────────────────────────────────
  Change:  -130.09 MB (-1.00%)
``` 