### PR TITLE
CI: Modernize CI workflow triggers and PR comment formatting.

### DIFF
--- a/.github/workflows/pr-comment-git-lfs.yml
+++ b/.github/workflows/pr-comment-git-lfs.yml
@@ -5,14 +5,16 @@ on:
     workflows: ["Test Git LFS"]
     types: [completed]
 
-# Write permissions for commenting
 permissions:
   pull-requests: write
+  actions: read
 
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.pull_requests[0] || startsWith(github.event.workflow_run.head_branch, 'pull-request/'))
 
     steps:
       - name: Download PR comment data
@@ -28,15 +30,25 @@ jobs:
           script: |
             const fs = require('fs');
 
-            // Read PR number and error details from artifacts
-            const prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
-            const errorType = fs.readFileSync('error_type', 'utf8').trim();
-            const errorFiles = fs.readFileSync('error_files', 'utf8').trim();
-
+            const pullRequests = context.payload.workflow_run.pull_requests;
+            let prNumber;
+            if (pullRequests && pullRequests.length > 0) {
+              prNumber = pullRequests[0].number;
+            } else {
+              try {
+                prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
+              } catch (e) {
+                console.log('No PR number found, skipping comment.');
+                return;
+              }
+            }
             if (!prNumber || isNaN(prNumber)) {
               console.log('No valid PR number found, skipping comment.');
               return;
             }
+
+            const errorType = fs.readFileSync('error_type', 'utf8').trim();
+            const errorFiles = fs.readFileSync('error_files', 'utf8').trim();
 
             if (!errorType) {
               console.log('No error type found, skipping comment.');

--- a/.github/workflows/pr-comment-git-lfs.yml
+++ b/.github/workflows/pr-comment-git-lfs.yml
@@ -59,46 +59,63 @@ jobs:
 
             let commentBody;
             if (errorType === 'subdir_gitattributes') {
-              commentBody = `## ❌ Git LFS Check Failed
+              const fileList = errorFiles.split('\n').map(f => f.trim()).filter(f => f).map(f => '- `' + f + '`').join('\n');
+              commentBody = `
+              ## ❌ Git LFS Check Failed
 
-            **Found \`.gitattributes\` file(s) in subdirectories.** Only the top-level \`.gitattributes\` should be used for LFS configuration.
+              🔗 [View workflow run logs](${runUrl})
 
-            🔗 [View workflow run logs](${runUrl})
+              **Found \`.gitattributes\` file(s) in subdirectories.** Only the top-level \`.gitattributes\` should be used for LFS configuration.
 
-            ### Files to remove:
-            ${errorFiles.split('\n').map(f => f.trim()).filter(f => f).map(f => '- \`' + f + '\`').join('\n')}
+              <details>
+              <summary>Files to remove</summary>
 
-            ### How to fix:
-            \`\`\`bash
-            git rm <path/to/.gitattributes>
-            git commit -m "Remove subdirectory .gitattributes"
-            \`\`\`
-            `;
+              ${fileList}
+
+              </details>
+
+              ### How to fix:
+
+              \`\`\`bash
+              git rm <path/to/.gitattributes>
+              git commit -m "Remove subdirectory .gitattributes"
+              \`\`\`
+
+              📚 [Git LFS documentation](https://git-lfs.com/)
+              `.replace(/^ {14}/gm, '').trim();
             } else if (errorType === 'not_lfs_tracked') {
-              commentBody = `## ❌ Git LFS Check Failed
+              commentBody = `
+              ## ❌ Git LFS Check Failed
 
-            **The following files should be tracked by Git LFS but are not:**
+              🔗 [View workflow run logs](${runUrl})
 
-            🔗 [View workflow run logs](${runUrl})
+              **The following files should be tracked by Git LFS but are not:**
 
-            ${errorFiles}
+              <details>
+              <summary>Files not tracked by LFS</summary>
 
-            ### How to fix:
-            \`\`\`bash
-            # For each file listed above:
-            git rm --cached <file>
-            git add <file>
-            git commit -m "Track file with Git LFS"
-            \`\`\`
+              ${errorFiles}
 
-            Make sure Git LFS is installed locally (\`git lfs install\`) before running these commands.
-            `;
+              </details>
+
+              ### How to fix:
+
+              \`\`\`bash
+              # For each file listed above:
+              git rm --cached <file>
+              git add <file>
+              git commit -m "Track file with Git LFS"
+              \`\`\`
+
+              Make sure Git LFS is installed locally (\`git lfs install\`) before running these commands.
+
+              📚 [Git LFS documentation](https://git-lfs.com/)
+              `.replace(/^ {14}/gm, '').trim();
             } else {
               console.log(`Unknown error type: ${errorType}, skipping comment.`);
               return;
             }
 
-            // Check if we already commented on this PR to avoid spam
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr-comment-git-signatures.yml
+++ b/.github/workflows/pr-comment-git-signatures.yml
@@ -5,14 +5,16 @@ on:
     workflows: ["Test Git Signatures"]
     types: [completed]
 
-# Write permissions for commenting
 permissions:
   pull-requests: write
+  actions: read
 
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.pull_requests[0] || startsWith(github.event.workflow_run.head_branch, 'pull-request/'))
 
     steps:
       - name: Download PR comment data
@@ -28,15 +30,25 @@ jobs:
           script: |
             const fs = require('fs');
 
-            // Read PR number and error details from artifacts
-            const prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
-            const unsignedCount = fs.readFileSync('unsigned_count', 'utf8').trim();
-            const unsignedCommits = fs.readFileSync('unsigned_commits', 'utf8').trim();
-
+            const pullRequests = context.payload.workflow_run.pull_requests;
+            let prNumber;
+            if (pullRequests && pullRequests.length > 0) {
+              prNumber = pullRequests[0].number;
+            } else {
+              try {
+                prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
+              } catch (e) {
+                console.log('No PR number found, skipping comment.');
+                return;
+              }
+            }
             if (!prNumber || isNaN(prNumber)) {
               console.log('No valid PR number found, skipping comment.');
               return;
             }
+
+            const unsignedCount = fs.readFileSync('unsigned_count', 'utf8').trim();
+            const unsignedCommits = fs.readFileSync('unsigned_commits', 'utf8').trim();
 
             if (!unsignedCount || unsignedCount === '0') {
               console.log('No unsigned commits found, skipping comment.');

--- a/.github/workflows/pr-comment-git-signatures.yml
+++ b/.github/workflows/pr-comment-git-signatures.yml
@@ -57,17 +57,21 @@ jobs:
 
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${{ github.event.workflow_run.id }}`;
 
-            const commentBody = `## ❌ Commit Signature Check Failed
-
-            **Found ${unsignedCount} unsigned commit(s):**
+            const commentBody = `
+            ## ❌ Git Signature Check Failed
 
             🔗 [View workflow run logs](${runUrl})
 
+            **Found ${unsignedCount} unsigned commit(s):**
+
+            <details>
+            <summary>Unsigned commits</summary>
+
             ${unsignedCommits}
 
-            ### All commits must be signed
+            </details>
 
-            #### How to fix:
+            ### How to fix:
 
             1. **Configure commit signing** (if not already done):
                \`\`\`bash
@@ -86,9 +90,8 @@ jobs:
                \`\`\`
 
             📚 [GitHub documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification)
-            `;
+            `.replace(/^ {12}/gm, '').trim();
 
-            // Check if we already commented on this PR to avoid spam
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -97,7 +100,7 @@ jobs:
 
             const botComment = comments.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('Commit Signature Check Failed')
+              comment.body.includes('Git Signature Check Failed')
             );
 
             if (botComment) {

--- a/.github/workflows/pr-comment-links.yml
+++ b/.github/workflows/pr-comment-links.yml
@@ -61,7 +61,8 @@ jobs:
               ? `\n<details>\n<summary>Broken links found by Lychee</summary>\n\n${errorDetails}\n\n</details>\n`
               : '';
 
-            const commentBody = `## ❌ Link Check Failed
+            const commentBody = `
+            ## ❌ Link Check Failed
 
             🔗 [View workflow run logs](${runUrl})
             ${detailsSection}
@@ -79,9 +80,8 @@ jobs:
             \`\`\`
 
             📚 [Lychee documentation](https://github.com/lycheeverse/lychee)
-            `;
+            `.replace(/^ {12}/gm, '').trim();
 
-            // Check if we already commented on this PR to avoid spam
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr-comment-links.yml
+++ b/.github/workflows/pr-comment-links.yml
@@ -5,14 +5,16 @@ on:
     workflows: ["Test Links"]
     types: [completed]
 
-# Write permissions for commenting
 permissions:
   pull-requests: write
+  actions: read
 
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.pull_requests[0] || startsWith(github.event.workflow_run.head_branch, 'pull-request/'))
 
     steps:
       - name: Download PR comment data
@@ -28,9 +30,18 @@ jobs:
           script: |
             const fs = require('fs');
 
-            // Read PR number from artifact
-            const prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
-
+            const pullRequests = context.payload.workflow_run.pull_requests;
+            let prNumber;
+            if (pullRequests && pullRequests.length > 0) {
+              prNumber = pullRequests[0].number;
+            } else {
+              try {
+                prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
+              } catch (e) {
+                console.log('No PR number found, skipping comment.');
+                return;
+              }
+            }
             if (!prNumber || isNaN(prNumber)) {
               console.log('No valid PR number found, skipping comment.');
               return;
@@ -38,12 +49,22 @@ jobs:
 
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${{ github.event.workflow_run.id }}`;
 
+            let errorDetails = '';
+            try {
+              const raw = fs.readFileSync('error_output', 'utf8').trim();
+              if (raw) {
+                errorDetails = raw.length > 30000 ? raw.substring(0, 30000) + '\n\n... (truncated)' : raw;
+              }
+            } catch (e) {}
+
+            const detailsSection = errorDetails
+              ? `\n<details>\n<summary>Broken links found by Lychee</summary>\n\n${errorDetails}\n\n</details>\n`
+              : '';
+
             const commentBody = `## ❌ Link Check Failed
 
-            **Broken links were detected in this PR.**
-
-            Please check the [workflow run logs](${runUrl}) for details on which links are broken.
-
+            🔗 [View workflow run logs](${runUrl})
+            ${detailsSection}
             ### Common fixes:
 
             1. **Typo in URL** - Check for spelling mistakes in the link

--- a/.github/workflows/pr-comment-notebook-format.yml
+++ b/.github/workflows/pr-comment-notebook-format.yml
@@ -61,7 +61,8 @@ jobs:
               ? `\n<details>\n<summary>Notebooks with issues</summary>\n\n\`\`\`\n${errorDetails}\n\`\`\`\n\n</details>\n`
               : '';
 
-            const commentBody = `## ❌ Notebook Format Check Failed
+            const commentBody = `
+            ## ❌ Notebook Format Check Failed
 
             🔗 [View workflow run logs](${runUrl})
             ${detailsSection}
@@ -74,9 +75,10 @@ jobs:
             # Auto-fix a specific tutorial
             python3 brev/test-notebook-format.py <tutorial-name> --fix
             \`\`\`
-            `;
 
-            // Check if we already commented on this PR to avoid spam
+            📚 [nbformat documentation](https://nbformat.readthedocs.io/)
+            `.replace(/^ {12}/gm, '').trim();
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr-comment-notebook-format.yml
+++ b/.github/workflows/pr-comment-notebook-format.yml
@@ -5,14 +5,16 @@ on:
     workflows: ["Test Notebook Format"]
     types: [completed]
 
-# Write permissions for commenting
 permissions:
   pull-requests: write
+  actions: read
 
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.pull_requests[0] || startsWith(github.event.workflow_run.head_branch, 'pull-request/'))
 
     steps:
       - name: Download PR comment data
@@ -28,9 +30,18 @@ jobs:
           script: |
             const fs = require('fs');
 
-            // Read PR number from artifact
-            const prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
-
+            const pullRequests = context.payload.workflow_run.pull_requests;
+            let prNumber;
+            if (pullRequests && pullRequests.length > 0) {
+              prNumber = pullRequests[0].number;
+            } else {
+              try {
+                prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
+              } catch (e) {
+                console.log('No PR number found, skipping comment.');
+                return;
+              }
+            }
             if (!prNumber || isNaN(prNumber)) {
               console.log('No valid PR number found, skipping comment.');
               return;
@@ -38,22 +49,22 @@ jobs:
 
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${{ github.event.workflow_run.id }}`;
 
+            let errorDetails = '';
+            try {
+              const raw = fs.readFileSync('error_output', 'utf8').trim();
+              if (raw) {
+                errorDetails = raw.length > 30000 ? raw.substring(0, 30000) + '\n\n... (truncated)' : raw;
+              }
+            } catch (e) {}
+
+            const detailsSection = errorDetails
+              ? `\n<details>\n<summary>Notebooks with issues</summary>\n\n\`\`\`\n${errorDetails}\n\`\`\`\n\n</details>\n`
+              : '';
+
             const commentBody = `## ❌ Notebook Format Check Failed
 
-            **One or more Jupyter notebooks are not in canonical format.**
-
-            Please check the [workflow run logs](${runUrl}) for details on which notebooks have issues.
-
-            ### What is checked:
-
-            All notebooks must be in **canonical format** (the exact output of \`nbformat.write()\`):
-
-            1. **Canonical serialization** — 1-space indentation, sorted keys, standard separators
-            2. **Cell IDs** — every cell must have an \`id\` field (nbformat 4.5)
-            3. **Metadata conformance** — notebooks must have the standard metadata block (accelerator, colab, kernelspec, language_info)
-            4. **Clean outputs** — non-SOLUTION notebooks must have outputs, execution counts, and execution timing metadata cleared
-            5. **Well-formed outputs** — SOLUTION notebook outputs must be schema-valid (e.g. stream outputs need the \`name\` field)
-
+            🔗 [View workflow run logs](${runUrl})
+            ${detailsSection}
             ### How to fix:
 
             \`\`\`bash

--- a/.github/workflows/pr-comment-yaml.yml
+++ b/.github/workflows/pr-comment-yaml.yml
@@ -61,11 +61,12 @@ jobs:
               ? `\n<details>\n<summary>YAML lint errors</summary>\n\n\`\`\`\n${errorDetails}\n\`\`\`\n\n</details>\n`
               : '';
 
-            const commentBody = `## ❌ YAML Lint Check Failed
+            const commentBody = `
+            ## ❌ YAML Check Failed
 
             🔗 [View workflow run logs](${runUrl})
             ${detailsSection}
-            ### To lint YAML files locally:
+            ### How to fix:
 
             \`\`\`bash
             pip install yamllint
@@ -73,9 +74,8 @@ jobs:
             \`\`\`
 
             📚 [yamllint documentation](https://yamllint.readthedocs.io/)
-            `;
+            `.replace(/^ {12}/gm, '').trim();
 
-            // Check if we already commented on this PR to avoid spam
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -84,7 +84,7 @@ jobs:
 
             const botComment = comments.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('YAML Lint Check Failed')
+              comment.body.includes('YAML Check Failed')
             );
 
             if (botComment) {

--- a/.github/workflows/pr-comment-yaml.yml
+++ b/.github/workflows/pr-comment-yaml.yml
@@ -5,14 +5,16 @@ on:
     workflows: ["Test YAML"]
     types: [completed]
 
-# Write permissions for commenting
 permissions:
   pull-requests: write
+  actions: read
 
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.pull_requests[0] || startsWith(github.event.workflow_run.head_branch, 'pull-request/'))
 
     steps:
       - name: Download PR comment data
@@ -28,9 +30,18 @@ jobs:
           script: |
             const fs = require('fs');
 
-            // Read PR number from artifact
-            const prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
-
+            const pullRequests = context.payload.workflow_run.pull_requests;
+            let prNumber;
+            if (pullRequests && pullRequests.length > 0) {
+              prNumber = pullRequests[0].number;
+            } else {
+              try {
+                prNumber = parseInt(fs.readFileSync('pr_number', 'utf8').trim());
+              } catch (e) {
+                console.log('No PR number found, skipping comment.');
+                return;
+              }
+            }
             if (!prNumber || isNaN(prNumber)) {
               console.log('No valid PR number found, skipping comment.');
               return;
@@ -38,27 +49,26 @@ jobs:
 
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${{ github.event.workflow_run.id }}`;
 
+            let errorDetails = '';
+            try {
+              const raw = fs.readFileSync('error_output', 'utf8').trim();
+              if (raw) {
+                errorDetails = raw.length > 30000 ? raw.substring(0, 30000) + '\n\n... (truncated)' : raw;
+              }
+            } catch (e) {}
+
+            const detailsSection = errorDetails
+              ? `\n<details>\n<summary>YAML lint errors</summary>\n\n\`\`\`\n${errorDetails}\n\`\`\`\n\n</details>\n`
+              : '';
+
             const commentBody = `## ❌ YAML Lint Check Failed
 
-            **YAML syntax or formatting errors were detected in this PR.**
-
-            Please check the [workflow run logs](${runUrl}) for details on which files have issues.
-
-            ### Common fixes:
-
-            1. **Indentation errors** - YAML requires consistent indentation (use spaces, not tabs)
-            2. **Missing colons or quotes** - Check for proper key-value syntax
-            3. **Trailing spaces** - Remove whitespace at the end of lines
-            4. **Duplicate keys** - Each key in a mapping must be unique
-            5. **Invalid characters** - Ensure special characters are properly quoted
-
+            🔗 [View workflow run logs](${runUrl})
+            ${detailsSection}
             ### To lint YAML files locally:
 
             \`\`\`bash
-            # Install yamllint
             pip install yamllint
-
-            # Run yamllint on the repo (with line-length disabled)
             yamllint -d "{rules: {line-length: disable}}" .
             \`\`\`
 

--- a/.github/workflows/test-git-lfs.yml
+++ b/.github/workflows/test-git-lfs.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
-    types: [opened, reopened, synchronize]
+      - '!gh-readonly-queue/**'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+  cancel-in-progress: true
 
 # Minimal permissions - only read access needed for checks
 permissions:
@@ -23,18 +27,22 @@ jobs:
         id: git-lfs-check
         run: bash brev/test-git-lfs.bash .
 
-      - name: Save PR number and result
-        if: always() && github.event_name == 'pull_request'
+      - name: Get PR info
+        id: get-pr-info
+        if: always() && startsWith(github.ref_name, 'pull-request/')
+        uses: nv-gha-runners/get-pr-info@main
+
+      - name: Save PR comment data
+        if: always()
         run: |
           mkdir -p ./pr-comment-data
-          echo '${{ github.event.pull_request.number }}' > ./pr-comment-data/pr_number
-          echo '${{ steps.git-lfs-check.outcome }}' > ./pr-comment-data/outcome
-          # Capture outputs if they exist
           echo '${{ steps.git-lfs-check.outputs.error_type }}' > ./pr-comment-data/error_type
           echo '${{ steps.git-lfs-check.outputs.error_files }}' > ./pr-comment-data/error_files
+          PR_NUMBER='${{ startsWith(github.ref_name, 'pull-request/') && fromJSON(steps.get-pr-info.outputs.pr-info).number || '' }}'
+          echo "${PR_NUMBER}" > ./pr-comment-data/pr_number
 
       - name: Upload PR comment data
-        if: always() && github.event_name == 'pull_request'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pr-comment-data

--- a/.github/workflows/test-git-signatures.yml
+++ b/.github/workflows/test-git-signatures.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
-    types: [opened, reopened, synchronize]
+      - '!gh-readonly-queue/**'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+  cancel-in-progress: true
 
 # Minimal permissions - only read access needed for checks
 permissions:
@@ -107,19 +111,24 @@ jobs:
               console.log(`\n✅ All ${commitShas.length} commit(s) are properly signed.`);
             }
 
-      - name: Save PR number and result
-        if: always() && github.event_name == 'pull_request'
+      - name: Get PR info
+        id: get-pr-info
+        if: always() && startsWith(github.ref_name, 'pull-request/')
+        uses: nv-gha-runners/get-pr-info@main
+
+      - name: Save PR comment data
+        if: always()
         run: |
           mkdir -p ./pr-comment-data
-          echo '${{ github.event.pull_request.number }}' > ./pr-comment-data/pr_number
-          echo '${{ steps.signature-check.outcome }}' > ./pr-comment-data/outcome
           echo '${{ steps.signature-check.outputs.unsigned_count }}' > ./pr-comment-data/unsigned_count
           cat << 'EOF' > ./pr-comment-data/unsigned_commits
           ${{ steps.signature-check.outputs.unsigned_commits }}
           EOF
+          PR_NUMBER='${{ startsWith(github.ref_name, 'pull-request/') && fromJSON(steps.get-pr-info.outputs.pr-info).number || '' }}'
+          echo "${PR_NUMBER}" > ./pr-comment-data/pr_number
 
       - name: Upload PR comment data
-        if: always() && github.event_name == 'pull_request'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pr-comment-data

--- a/.github/workflows/test-links.yml
+++ b/.github/workflows/test-links.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
-    types: [opened, reopened, synchronize]
+      - '!gh-readonly-queue/**'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+  cancel-in-progress: true
 
 # Minimal permissions - only read access needed for checks
 permissions:
@@ -42,17 +46,26 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --verbose --no-progress --config brev/lychee.toml --exclude-file brev/.lycheeignore '.'
+          output: ./lychee/out.md
           fail: true
 
-      - name: Save PR number and result
-        if: always() && github.event_name == 'pull_request'
+      - name: Get PR info
+        id: get-pr-info
+        if: always() && startsWith(github.ref_name, 'pull-request/')
+        uses: nv-gha-runners/get-pr-info@main
+
+      - name: Save PR comment data
+        if: always()
         run: |
           mkdir -p ./pr-comment-data
-          echo '${{ github.event.pull_request.number }}' > ./pr-comment-data/pr_number
-          echo '${{ steps.lychee-check.outcome }}' > ./pr-comment-data/outcome
+          PR_NUMBER='${{ startsWith(github.ref_name, 'pull-request/') && fromJSON(steps.get-pr-info.outputs.pr-info).number || '' }}'
+          echo "${PR_NUMBER}" > ./pr-comment-data/pr_number
+          if [ -f ./lychee/out.md ]; then
+            cp ./lychee/out.md ./pr-comment-data/error_output
+          fi
 
       - name: Upload PR comment data
-        if: always() && github.event_name == 'pull_request'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pr-comment-data

--- a/.github/workflows/test-notebook-format.yml
+++ b/.github/workflows/test-notebook-format.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
-    types: [opened, reopened, synchronize]
+      - '!gh-readonly-queue/**'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+  cancel-in-progress: true
 
 # Minimal permissions - only read access needed for checks
 permissions:
@@ -29,17 +33,27 @@ jobs:
 
       - name: Check notebook format
         id: notebook-format-check
-        run: python3 brev/test-notebook-format.py
+        run: |
+          set -o pipefail
+          python3 brev/test-notebook-format.py 2>&1 | tee ./notebook-format-output.txt
 
-      - name: Save PR number and result
-        if: always() && github.event_name == 'pull_request'
+      - name: Get PR info
+        id: get-pr-info
+        if: always() && startsWith(github.ref_name, 'pull-request/')
+        uses: nv-gha-runners/get-pr-info@main
+
+      - name: Save PR comment data
+        if: always()
         run: |
           mkdir -p ./pr-comment-data
-          echo '${{ github.event.pull_request.number }}' > ./pr-comment-data/pr_number
-          echo '${{ steps.notebook-format-check.outcome }}' > ./pr-comment-data/outcome
+          PR_NUMBER='${{ startsWith(github.ref_name, 'pull-request/') && fromJSON(steps.get-pr-info.outputs.pr-info).number || '' }}'
+          echo "${PR_NUMBER}" > ./pr-comment-data/pr_number
+          if [ -f ./notebook-format-output.txt ]; then
+            sed 's/\x1b\[[0-9;]*m//g' ./notebook-format-output.txt > ./pr-comment-data/error_output
+          fi
 
       - name: Upload PR comment data
-        if: always() && github.event_name == 'pull_request'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pr-comment-data

--- a/.github/workflows/test-yaml.yml
+++ b/.github/workflows/test-yaml.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
-    types: [opened, reopened, synchronize]
+      - '!gh-readonly-queue/**'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+  cancel-in-progress: true
 
 # Minimal permissions - only read access needed for checks
 permissions:
@@ -30,17 +34,26 @@ jobs:
       - name: Lint YAML files
         id: yamllint-check
         run: |
-          yamllint -f github -d '{rules: {line-length: disable}}' .
+          set -o pipefail
+          yamllint -f parsable -d '{rules: {line-length: disable}}' . 2>&1 | tee ./yamllint-output.txt
 
-      - name: Save PR number and result
-        if: always() && github.event_name == 'pull_request'
+      - name: Get PR info
+        id: get-pr-info
+        if: always() && startsWith(github.ref_name, 'pull-request/')
+        uses: nv-gha-runners/get-pr-info@main
+
+      - name: Save PR comment data
+        if: always()
         run: |
           mkdir -p ./pr-comment-data
-          echo '${{ github.event.pull_request.number }}' > ./pr-comment-data/pr_number
-          echo '${{ steps.yamllint-check.outcome }}' > ./pr-comment-data/outcome
+          PR_NUMBER='${{ startsWith(github.ref_name, 'pull-request/') && fromJSON(steps.get-pr-info.outputs.pr-info).number || '' }}'
+          echo "${PR_NUMBER}" > ./pr-comment-data/pr_number
+          if [ -f ./yamllint-output.txt ]; then
+            cp ./yamllint-output.txt ./pr-comment-data/error_output
+          fi
 
       - name: Upload PR comment data
-        if: always() && github.event_name == 'pull_request'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pr-comment-data


### PR DESCRIPTION
## Summary

- Add `merge_group` trigger for GitHub merge queue support.
- Replace `pull_request` trigger with `push` to all branches (excluding `gh-readonly-queue/**` merge queue branches) to avoid redundant duplicate runs while still triggering CI on every push, even before a PR exists. Fork PRs are handled via NVIDIA's copy-pr-bot which copies code to `pull-request/N` branches.
- Add concurrency groups (matching the CCCL pattern) to cancel superseded runs on the same branch.
- Use `nv-gha-runners/get-pr-info` to resolve PR numbers on copy-pr-bot branches, with `workflow_run.pull_requests` as fallback for same-repo PRs.
- Capture specific failure output (lychee report, notebook format errors, yamllint errors) and include in PR comments via collapsible `<details>` blocks.
- Unify artifact upload/download pattern across all test and PR comment workflow pairs.
- Normalize PR comment headings, section levels, doc links, and markdown formatting.
- Fix comment body indentation that caused markdown rendering issues (headings/lists rendered as code blocks due to 12+ leading spaces in template literals).

> **Note:** The `workflow_run`-triggered PR comment workflows always run from the default branch, not the PR branch. This means:
> - **Testable on this PR:** test workflow triggers, concurrency groups, artifact uploads, `get-pr-info` integration.
> - **Only testable after merging to main:** PR failure comments (new formatting, `<details>` blocks, specific error output). The first PR that fails a check after this merges will exercise the comment workflows.
> - **Only testable after enabling merge queue:** the `merge_group` trigger.