### PR TITLE
User Guide: Use absolute URLs for notebook images to fix GitHub rendering

### DIFF
--- a/Accelerated_Python_User_Guide/notebooks/Chapter_01_GPU_Computing_Basics.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_01_GPU_Computing_Basics.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "The GPU Programming landscape is vast, and understanding both GPU programming concepts and Python GPU programming paradigms can be daunting.  In this guide, we hope to demystify the ecosystem and lead developers to the right solution to fit their particular accelerated computing needs.\n",
     "\n",
-    "![NVCube](images/chapter-01/cube.png)"
+    "![NVCube](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-01/cube.png)"
    ]
   },
   {
@@ -121,7 +121,7 @@
     "\n",
     "_A Simplified View of GPU Architecture_\n",
     "\n",
-    "![GPUArch](images/chapter-01/gpu-arch.png)\n"
+    "![GPUArch](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-01/gpu-arch.png)\n"
    ]
   },
   {
@@ -146,7 +146,7 @@
     "## Evolution of Nvidia GPUs\n",
     "Many options, you can choose from consumer-grade GPUs, data center GPUs, and managed workstations.\n",
     "\n",
-    "![GPUHW](images/chapter-01/gpu-hw.png)\n",
+    "![GPUHW](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-01/gpu-hw.png)\n",
     "\n",
     "### Consumer-Grade GPUs\n",
     "\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_02_Brief_Intro_to_CUDA.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_02_Brief_Intro_to_CUDA.ipynb
@@ -55,7 +55,7 @@
     "\n",
     "_GPU Kernel Execution_\n",
     "\n",
-    "![KernelExecution](images/chapter-02/gpu-kernel-exec.png)\n",
+    "![KernelExecution](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-02/gpu-kernel-exec.png)\n",
     "\n",
     "The hierarchical structure of these components not only aid in the management of thread execution, but also reflects the physical architecture of CUDA-enabled GPUs.  Threads are executed concurrently on multiple Streaming Multiprocessors (SMs).\n"
    ]
@@ -75,7 +75,7 @@
     "- Local - Private to each thread, but part of global memory.\n",
     "- Registers - Private to each thread.\n",
     "\n",
-    "![GPUMemory](images/chapter-02/gpu-memory.png)\n",
+    "![GPUMemory](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-02/gpu-memory.png)\n",
     "\n",
     "There are other types of memory to be aware of, but may be out of scope for crafting accelerated Python applications with high-level libraries.\n",
     "- Constant memory - Cached read-only memory with access by all threads.  In the case of an NVIDIA GPU, the shared memory, the L1 cache and the Constant memory cache are within the streaming multiprocessor block. Hence they are faster than the L2 cache, and GPU RAM\n",
@@ -87,7 +87,7 @@
     "\n",
     "_Memory Hierarchy_\n",
     "\n",
-    "![GPUMemoryHierarchy](images/chapter-02/gpu-memory-hierarchy.png)\n",
+    "![GPUMemoryHierarchy](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-02/gpu-memory-hierarchy.png)\n",
     "\n",
     "The architecture creates a pool of managed memory where each allocation from this memory pool is accessible on both the host and the device with the same address or pointer. The underlying system migrates data to both the host and device.\n",
     "\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_03_Python_on_the_GPU.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_03_Python_on_the_GPU.ipynb
@@ -34,11 +34,11 @@
     "\n",
     "Besides being more efficient for numerical computations than native Python code, NumPy can also be more elegant and readable due to vectorized operations and broadcasting, which are features that we will explore in this article.\n",
     "\n",
-    "![UsesNumPy](images/chapter-03/uses-numpy.png)\n",
+    "![UsesNumPy](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-03/uses-numpy.png)\n",
     "\n",
     "Today, NumPy helps form the basis of the scientific Python computing ecosystem. (see numpy.org) There are already GPU accelerated versions of these fundamental libraries being developed, but there is an opportunity for all scientific libraries to take advantage of these optimizations.\n",
     "\n",
-    "![ScipyEcosystem](images/chapter-03/scipy-eco.png)\n"
+    "![ScipyEcosystem](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-03/scipy-eco.png)\n"
    ]
   },
   {

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_04_Scientific_Computing_with_CuPy.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_04_Scientific_Computing_with_CuPy.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Chapter 4: Scientific Computing with CuPy\n",
     "\n",
-    "<img src=\"images/chapter-04/cupy_title.png\" style=\"width:600px;\"/>\n",
+    "<img src=\"https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-04/cupy_title.png\" style=\"width:600px;\"/>\n",
     "\n",
     "CuPy is a NumPy and SciPy-compatible array library for GPU-accelerated computing with Python. CuPy acts as a drop-in replacement to run existing NumPy and SciPy code on NVIDIA CUDA or AMD ROCm platforms.\n",
     "\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_05_CUDA_Kernels_with_Numba.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_05_CUDA_Kernels_with_Numba.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Chapter 5: CUDA Kernels with Numba\n",
     "\n",
-    "<img src=\"images/chapter-05/numba_title.png\" style=\"width:442px;\"/>\n",
+    "<img src=\"https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-05/numba_title.png\" style=\"width:442px;\"/>\n",
     "\n",
     "Numba is an open source JIT compiler that translates a subset of Python and NumPy code into fast machine code.\n",
     "\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_06_Intro_to_nvmath-python.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_06_Intro_to_nvmath-python.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Chapter 6: Introduction to nvmath-python\n",
     "\n",
-    "<img src=\"images/chapter-06/nvmath-python.jpg\" style=\"width:600px;\"/>\n",
+    "<img src=\"https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-06/nvmath-python.jpg\" style=\"width:600px;\"/>\n",
     "\n",
     "The **nvmath-python** (Beta) library brings the power of the NVIDIA math libraries to the Python ecosystem. The package aims to provide intuitive pythonic APIs that provide users full access to all the features offered by NVIDIA’s libraries in a variety of execution spaces. nvmath-python works seamlessly with existing Python array/tensor frameworks and focuses on providing functionality that is missing from those frameworks.\n",
     "\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_07_Intro_to_cuDF.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_07_Intro_to_cuDF.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Chapter 7: Dataframes with cuDF\n",
     "\n",
-    "<img src=\"images/chapter-07/RAPIDS-logo-purple.png\" style=\"width:600px;\"/>\n",
+    "<img src=\"https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-07/RAPIDS-logo-purple.png\" style=\"width:600px;\"/>\n",
     "\n",
     "cuDF is a DataFrame library for GPU-accelerated computing with Python. cuDF provides a pandas-like API that will be familiar to data engineers & data scientists, so they can use it to easily accelerate their workflows without going into the details of CUDA programming.\n",
     "\n",
@@ -26,7 +26,7 @@
     "\n",
     "cuDF primarily acts upon the DataFrame data structure.  A DataFrame is a 2-dimensional data structure that can store data of different types (including characters, integers, floating point values, categorical data and more) in columns. It is similar to a spreadsheet, a SQL table or the `data.frame` in R.\n",
     "\n",
-    "<img src=\"images/chapter-07/dataframe.png\" style=\"width:600px;\"/>\n",
+    "<img src=\"https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-07/dataframe.png\" style=\"width:600px;\"/>\n",
     "\n"
    ]
   },
@@ -102,7 +102,7 @@
    "id": "b48d43f7-92ff-4e44-a41f-db07f08b3e1d",
    "metadata": {},
    "source": [
-    "<img src=\"images/chapter-07/inference-data-analytics-featured.jpg\" style=\"width:600px;\"/>\n",
+    "<img src=\"https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-07/inference-data-analytics-featured.jpg\" style=\"width:600px;\"/>\n",
     "\n",
     "## The latest in cuDF integration: Polars GPU engine\n",
     "Polars is one of the fastest growing Python libraries for data scientists and engineers, and was designed from the ground up to address these challenges. It uses advanced query optimizations to reduce unnecessary data movement and processing, allowing data scientists to smoothly handle workloads of hundreds of millions of rows in scale on a single machine. Polars bridges the gap where single-threaded solutions are too slow, and distributed systems add unnecessary complexity, offering an appealing “medium-scale” data processing solution.\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_08_Intro_to_cuML.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_08_Intro_to_cuML.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Chapter 8: Machine Learning using cuML\n",
     "\n",
-    "<img src=\"images/chapter-08/rapids_logo.png\" style=\"width:600px;\"/>\n",
+    "<img src=\"https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-08/rapids_logo.png\" style=\"width:600px;\"/>\n",
     "\n",
     "As part of the NVIDIA RAPIDS suite, cuML is incredibly useful for accelerating the end-to-end machine learning pipeline, from data preprocessing to model training and evaluation, utilizing the parallel processing capabilities of NVIDIA GPUs. \n",
     "\n",
@@ -100,7 +100,7 @@
    "id": "57a2163b-aa0f-4b9c-aa34-b846d87e4b58",
    "metadata": {},
    "source": [
-    "<img src=\"images/chapter-08/nvidia-cuda-ml.jpg\" style=\"width:800px;\"/>\n",
+    "<img src=\"https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-08/nvidia-cuda-ml.jpg\" style=\"width:800px;\"/>\n",
     "\n",
     "# Coding Guide\n",
     "\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Chapter 9: Graphs with cuGraph\n",
     "\n",
-    "<img src=\"images/chapter-09/cugraph_logo_2.png\" style=\"width:600px;\"/>\n",
+    "<img src=\"https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-09/cugraph_logo_2.png\" style=\"width:600px;\"/>\n",
     "\n",
     "cuGRAPH is part of the RAPIDS AI suite and provides a set of graph analytics algorithms optimized for GPU performance. It supports various graph data structures and algorithms, enabling rapid processing of large-scale graph data.\n",
     "\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_10_Developer_Tools.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_10_Developer_Tools.ipynb
@@ -168,7 +168,7 @@
     "\n",
     "Once the profile completes, find the Python process thread under the **Processes** row on the timeline. Zoom in to the active portion of the Python thread by left-clicking and dragging across the area of interest to select it. Then right-click to \"Zoom into selection\". If you hover over a sample in the **Python Backtrace** row, a popup will appear with the call stack that was currently executing when the sample was taken.\n",
     "\n",
-    "![cupy1](images/chapter-10/cupy-profiling-1.png)"
+    "![cupy1](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/cupy-profiling-1.png)"
    ]
   },
   {
@@ -178,7 +178,7 @@
    "source": [
     "CuPy will call CUDA kernels under the hood as it executes. Nsight Systems will automatically detect these. Expand the **CUDA HW** row to see where the kernels are scheduled.\n",
     "\n",
-    "![cupy2](images/chapter-10/cupy-profiling-2.png)"
+    "![cupy2](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/cupy-profiling-2.png)"
    ]
   },
   {
@@ -188,7 +188,7 @@
    "source": [
     "Look at the **GPU Metrics > GPU Active** and **SM Instructions** rows to verify that the GPU is being used. You can hover over a spot in this row to see the % Utilization.\n",
     "\n",
-    "![cupy3](images/chapter-10/cupy-profiling-3.png)"
+    "![cupy3](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/cupy-profiling-3.png)"
    ]
   },
   {
@@ -259,7 +259,7 @@
     "\n",
     "In this particular example, we can see in the **GPU Metrics > SM Instructions > Tensor Active** row that the Tensor cores on the GPU are not active while the kernels are running. Tensor cores can add a lot of performance to computation-intensive kernels. The next step will be to get them active. \n",
     "\n",
-    "![cupy4](images/chapter-10/cupy-profiling-4.png)"
+    "![cupy4](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/cupy-profiling-4.png)"
    ]
   },
   {
@@ -329,7 +329,7 @@
    "id": "aad24b03-9d44-455c-a2c2-9e65fcd6749a",
    "metadata": {},
    "source": [
-    "![cupy5](images/chapter-10/cupy-profiling-5.png)\n",
+    "![cupy5](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/cupy-profiling-5.png)\n",
     "\n",
     "**Notice** that the tensor cores are now being used during the dot product and the runtime of the dot range on the GPU is shorter 312ms ->116ms."
    ]
@@ -355,12 +355,12 @@
     "```\n",
     "This json object indicates that the functions “random.random”, “dot”, and, “sort” from the module “cupy” should be traced and displayed as a black range on the timeline. Add this file to the “Python Functions trace” field in the configuration as shown below. \n",
     "\n",
-    "![cupy6](images/chapter-10/cupy-profiling-6.png)\n",
+    "![cupy6](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/cupy-profiling-6.png)\n",
     "\n",
     "To do this from the CLI, add a flag like \" --python-functions-trace=\"/home/myusername/cupy_annotations.json\" \"\n",
     "Run another profile to see the automatic tracing.\n",
     "\n",
-    "![cupy7](images/chapter-10/cupy-profiling-7.png)\n"
+    "![cupy7](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/cupy-profiling-7.png)\n"
    ]
   },
   {
@@ -382,7 +382,7 @@
     "\n",
     "To profile a Numba application with Nsight Compute, open the “Connect” dialog from the GUI. Select the python interpreter binary as the “Application Executable”. Ensure this interpreter runs in the environment with all the necessary dependencies for the application, for example the Conda shell supporting Numba. Then fill in the “Working Directory” field and put your Python file and any additional command line arguments in the “Command Line Arguments” field. This tells Nsight Compute how to launch your workload for profiling.\n",
     "\n",
-    "![numba1](images/chapter-10/numba-profiling-1.png)"
+    "![numba1](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/numba-profiling-1.png)"
    ]
   },
   {
@@ -456,25 +456,25 @@
    "source": [
     "When the profile completes, the **Summary** page shows an overview of the kernels profiled. In this example, it’s only one. Expanding the “Demangled Name” column shows that this is the “vecadd” kernel that we wrote with Numba. The Summary has some basic information including the kernel duration and compute and memory throughput. It also lists top performance rules that were triggered and estimated speedups for correcting them. \n",
     "\n",
-    "![numba2](images/chapter-10/numba-profiling-2.png)\n",
+    "![numba2](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/numba-profiling-2.png)\n",
     "\n",
     "Double clicking on the kernel will open the **Details** page with much more information.\n",
     "\n",
     "The “GPU Speed of Light Throughput” section at the top shows that this kernel has much higher Memory usage than Compute. The Memory Workload Analysis section shows significant traffic to device memory. \n",
     "\n",
-    "![numba3](images/chapter-10/numba-profiling-3.png)\n",
+    "![numba3](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/numba-profiling-3.png)\n",
     "\n",
     "The Compute Workload Analysis section shows the majority of the compute is using the FP64 pipeline. \n",
     "\n",
-    "![numba4](images/chapter-10/numba-profiling-4.png)\n",
+    "![numba4](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/numba-profiling-4.png)\n",
     "\n",
     "The Source Counters section at the bottom shows the source locations with the most stalls and clicking on one opens the **Source** page. \n",
     "\n",
-    "![numba5](images/chapter-10/numba-profiling-5.png)\n",
+    "![numba5](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/numba-profiling-5.png)\n",
     "\n",
     "Since this was a very simple kernel, most of the stalls are on the addition statement, but with more complex kernels, this level of detail is invaluable. Additionally, the **Context** page will show the CPU call stack that led to this kernel being executed. \n",
     "\n",
-    "![numba6](images/chapter-10/numba-profiling-6.png)"
+    "![numba6](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/numba-profiling-6.png)"
    ]
   },
   {
@@ -494,7 +494,7 @@
     "\n",
     "After switching to the FP32 datatype and rerunning a profile, we can see that the runtime of the kernel decreased significantly as did the memory traffic. Setting the initial result to the [Baseline](https://docs.nvidia.com/nsight-compute/NsightCompute/index.html#id7) and opening up the new result will automatically compare the two. Notice that the FP64 usage has disappeared and the kernel has sped up from 59us to 33us. \n",
     "\n",
-    "![Img7](images/chapter-10/numba-profiling-7.png)\n"
+    "![Img7](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/numba-profiling-7.png)\n"
    ]
   },
   {
@@ -603,7 +603,7 @@
    "id": "b2012c37-ef02-487c-9580-4b8639a82cee",
    "metadata": {},
    "source": [
-    "![sanitizer1](images/chapter-10/numba-sanitizer-1.png)"
+    "![sanitizer1](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/numba-sanitizer-1.png)"
    ]
   },
   {
@@ -742,7 +742,7 @@
    "id": "09119ff2-0134-4dfe-89c8-4f1b7df6a904",
    "metadata": {},
    "source": [
-    "![sanitizer2](images/chapter-10/numba-sanitizer-2.png)"
+    "![sanitizer2](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-10/numba-sanitizer-2.png)"
    ]
   },
   {

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_12.1_IsingModel_In_Warp.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_12.1_IsingModel_In_Warp.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "# Chapter 12.1: GPU-Accelerated Ising Model Simulation in NVIDIA Warp\n",
     "\n",
-    "![Example output](images/chapter-12.1/ising_animation.gif)\n",
+    "![Example output](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-12.1/ising_animation.gif)\n",
     "\n",
     "\n",
     "## Overview\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_12_Intro_to_NVIDIA_Warp.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_12_Intro_to_NVIDIA_Warp.ipynb
@@ -437,7 +437,7 @@
     "  - This is not an important detail for the purposes of using **NVIDIA Warp**, but it's worth mentioning this potential source of naming confusion.\n",
     "- Individual threads within a hardware warp execute their instructions on **CUDA cores** within the SM\n",
     "\n",
-    "![Execution Hierarchy on a GPU](images/chapter-02//gpu-kernel-exec.png)\n",
+    "![Execution Hierarchy on a GPU](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-02/gpu-kernel-exec.png)\n",
     "\n",
     "*Image credit: [NVIDIA Developer Blog](https://developer.nvidia.com/blog/cuda-refresher-cuda-programming-model/)*"
    ]

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_nvshmem4py.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_nvshmem4py.ipynb
@@ -70,7 +70,7 @@
     "\n",
     "### The Symmetric Heap\n",
     "\n",
-    "![sym_heap](images/chapter-nvshmem4py/sym_heap.png)\n",
+    "![sym_heap](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-nvshmem4py/sym_heap.png)\n",
     "\n",
     "An NVSHMEM program consists of data objects that are private to each PE (rank) and data objects that are remotely accessible by all PEs. Private data objects are stored in the local memory of each PE and can only be accessed by the PE itself; these data objects cannot be accessed by other PEs via NVSHMEM routines. Private data objects follow the memory model of C. Remotely accessible objects, however, can be accessed by remote PEs using NVSHMEM routines. Remotely accessible data objects are called Symmetric Data Objects. Each Symmetric Data Object has a corresponding object with the same name, type, and size on all PEs where that object is accessible via the NVSHMEM API.\n",
     "\n",

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_nvshmem4py_device.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_nvshmem4py_device.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "The following image shows the initial setup of elements on 4 PEs. Signal and chunking is not represented for simplicity.\n",
     "\n",
-    "![NVSHMEM4Py Device API Overview](images/chapter-nvshmem4py-device/1.png)\n"
+    "![NVSHMEM4Py Device API Overview](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-nvshmem4py-device/1.png)\n"
    ]
   },
   {
@@ -122,19 +122,19 @@
     "\n",
     "Initially, PE0 sends its local data to the next PE. Once finished, it increments PE1's signal flag by 1.\n",
     "\n",
-    "![Reduction-1](images/chapter-nvshmem4py-device/2.png)\n",
+    "![Reduction-1](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-nvshmem4py-device/2.png)\n",
     "\n",
     "Meanwhile, PE1 was waiting for an update to the signal flag. Once received, it indicates that PE0 has sent its data. It now performs a local compute.\n",
     "\n",
-    "![Reduction-1](images/chapter-nvshmem4py-device/3.png)\n",
+    "![Reduction-1](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-nvshmem4py-device/3.png)\n",
     "\n",
     "Once compute finishes, PE1 sends the data to the next PE. The next PE waits for the signal, and then performs local compute. It iterates to the last PE.\n",
     "\n",
-    "![Reduction-1](images/chapter-nvshmem4py-device/4.png)\n",
+    "![Reduction-1](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-nvshmem4py-device/4.png)\n",
     "\n",
     "On the last PE, once the compute finishes, it sends the result to PE0. Notice this time the result is already the final reduced result. PE0 is waiting for a signal to be updated. After receiving, it enters the broadcast phase.\n",
     "\n",
-    "![Reduction-1](images/chapter-nvshmem4py-device/5.png)\n",
+    "![Reduction-1](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-nvshmem4py-device/5.png)\n",
     "\n",
     "Each Cooperative Thread Array (CTA) handles a \"chunk\" of data within its assigned range for each iteration. Each chunk is handled independently from other chunks."
    ]
@@ -180,7 +180,7 @@
     "\n",
     "The broadcast phase is kicked off by the last PE's `put` instruction to PE0. Once PE0 receives the final result, a chain of `put`s are invoked following the PE order. Afterward, all PEs possess the final computed result.\n",
     "\n",
-    "![Broadcast-1](images/chapter-nvshmem4py-device/6.png)"
+    "![Broadcast-1](https://media.githubusercontent.com/media/NVIDIA/accelerated-computing-hub/main/Accelerated_Python_User_Guide/notebooks/images/chapter-nvshmem4py-device/6.png)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- GitHub's notebook renderer resolves relative image paths via `raw.githubusercontent.com`, which serves Git LFS pointer files as `text/plain` instead of actual image content. This breaks all LFS-tracked images in the Accelerated Python User Guide notebooks when viewed on GitHub.
- Replaced 42 relative image paths across 14 notebooks with absolute `media.githubusercontent.com` URLs, which correctly serve LFS content.
- SVG references (not in LFS) are left as relative paths.
- Normalized a double-slash in one path (`chapter-02//gpu-kernel-exec.png`).

See [brycelelbach/jupyter-github-relative-image-test](https://github.com/brycelelbach/jupyter-github-relative-image-test) for a minimal reproduction of the underlying GitHub bug.