### PR TITLE
Tutorials/GPU Deployment: Fix broken Brev CLI documentation link

### DIFF
--- a/tutorials/gpu-deployment/gpu-deployment-from-scratch.md
+++ b/tutorials/gpu-deployment/gpu-deployment-from-scratch.md
@@ -47,7 +47,7 @@ Once your VM is deployed, follow the Brev access instructions provided for your 
   - `brev ls` to list your VMs
   - `brev shell <your vm name>` to connect via SSH
 
-For Linux and Windows instructions check the [brev-cli install documentation](https://docs.nvidia.com/brev/latest/brev-cli.html#installation-instructions)
+For Linux and Windows instructions check the [brev-cli install documentation](https://docs.nvidia.com/brev/latest/cli/getting-started#installation)
 
 ### Exploring our GPU Software Environment
 


### PR DESCRIPTION
## Summary
- The Brev CLI installation docs URL (`docs.nvidia.com/brev/latest/brev-cli.html#installation-instructions`) now returns 404.
- Updated to the current documentation location (`docs.nvidia.com/brev/latest/cli/getting-started#installation`).
- Verified the new link resolves successfully via `brev/test-links.bash`.

## Test plan
- [x] Ran `brev/test-links.bash tutorials/gpu-deployment` — 0 errors.
- [x] Ran full repo link test (`brev/test-links.bash .`) — this was the only broken link.