### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-brev-tutorial-docker-images.yml
+++ b/.github/workflows/build-brev-tutorial-docker-images.yml
@@ -21,6 +21,8 @@ on:
 jobs:
   discover-tutorials:
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Potential fix for [https://github.com/NVIDIA/accelerated-computing-hub/security/code-scanning/1](https://github.com/NVIDIA/accelerated-computing-hub/security/code-scanning/1)

Add an explicit `permissions` block to the `discover-tutorials` job in `.github/workflows/build-brev-tutorial-docker-images.yml`.

Best fix (without changing functionality): set minimal required permission for checkout and read operations:
- `contents: read`

This should be added directly under `runs-on` (or near other job-level keys) for `discover-tutorials`. No imports, methods, or external definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
