### PR TITLE
CI: Disable flaky link checking in CI and pre-commit.

### DIFF
--- a/.github/workflows/pr-comment-links.yml
+++ b/.github/workflows/pr-comment-links.yml
@@ -1,9 +1,10 @@
 name: PR Comment on Link Check
 
+# Disabled along with the "Test Links" workflow (see test-links.yml). Link
+# checking is flaky, so the automatic link-check PR comment is turned off.
+# Retained for manual dispatch only.
 on:
-  workflow_run:
-    workflows: ["Test Links"]
-    types: [completed]
+  workflow_dispatch:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/test-links.yml
+++ b/.github/workflows/test-links.yml
@@ -1,11 +1,12 @@
 name: Test Links
 
+# Automatic link checking is disabled: the lychee-based link checks are flaky
+# (external sites intermittently time out or rate-limit, producing spurious CI
+# failures). The workflow is retained and can still be run on demand from the
+# Actions tab via "Run workflow". To check links locally, run
+# `./brev/test-links.bash .`.
 on:
-  push:
-    branches:
-      - '**'
-      - '!gh-readonly-queue/**'
-  merge_group:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,15 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+      # Link checking is flaky (external sites intermittently time out or
+      # rate-limit), so these hooks are manual-only and do not run on commit.
+      # Run on demand with `pre-commit run --hook-stage manual test-links`.
       - id: test-links
         name: Check links in changed markdown and notebooks
         entry: bash brev/test-links.bash
         language: system
         files: '\.(md|ipynb)$'
+        stages: [manual]
 
       - id: test-links-all
         name: Check links in all markdown and notebooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ The following hooks are configured:
 | **`notebook-format`** | pre-commit | `*.ipynb` | Validates that notebooks are in canonical format (consistent cell metadata, output ordering, etc.) to prevent noisy diffs from editor reformatting. |
 | **`git-lfs`** | pre-commit | Binary files (`*.pptx`, `*.pdf`, `*.png`, `*.jpg`, etc.) | Ensures binary files are tracked by Git LFS rather than committed directly to the repository. |
 | **`git-signatures`** | pre-push | All commits | Verifies that all commits being pushed have valid cryptographic signatures (see [Signing Your Commits](#signing-your-commits)). |
-| **`test-links`** | manual | `*.md`, `*.ipynb` | Checks for broken links in markdown and notebook files. Run manually with `pre-commit run test-links --all-files`. |
+| **`test-links`** | manual | `*.md`, `*.ipynb` | Checks for broken links in markdown and notebook files. Manual-only because link checking is flaky (external sites intermittently time out or rate-limit). Run with `pre-commit run --hook-stage manual test-links --all-files`. |
 
 If a hook fails, fix the issue and re-stage your changes before committing again.
 
@@ -220,11 +220,17 @@ cryptographically signed. Runs on `git push`, not on commit. See
 [GitHub's documentation on commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification)
 for setup instructions.
 
-### `test-links` (pre-commit)
+### `test-links` (manual)
 
 Checks that links in changed Markdown files and Jupyter notebooks are valid
-using [lychee](https://github.com/lycheeverse/lychee). Only files modified in
-the commit are checked.
+using [lychee](https://github.com/lycheeverse/lychee). This hook is **manual**
+and does not run automatically on commit, because link checking is flaky
+(external sites intermittently time out or rate-limit, producing spurious
+failures). Run it explicitly with:
+
+```bash
+pre-commit run --hook-stage manual test-links
+```
 
 ### `test-links-all` (manual)
 


### PR DESCRIPTION
## What

Disables automatic link checking in both CI and pre-commit, while retaining the machinery so links can still be checked on demand.

- **`.github/workflows/test-links.yml`** — triggers on `workflow_dispatch` only (was `push` on all branches + `merge_group`).
- **`.github/workflows/pr-comment-links.yml`** — triggers on `workflow_dispatch` only. Its only purpose was to post a PR comment when *Test Links* failed, so it is disabled alongside it.
- **`.pre-commit-config.yaml`** — the `test-links` hook is moved to the `manual` stage so it no longer runs on commit (`test-links-all` was already `manual`).
- **`CONTRIBUTING.md`** — documents `test-links` as manual-only and explains why.

## Why

The lychee-based link checks are **flaky**: external sites intermittently time out or rate-limit, producing spurious failures that block CI and local commits even when the changed content is correct.

## Nothing is removed

The link checker can still be run on demand:

- From the **Actions** tab via **Run workflow** (`workflow_dispatch`).
- Via pre-commit: `pre-commit run --hook-stage manual test-links`
- Locally: `./brev/test-links.bash .`

The `brev/test-links.bash` script, `brev/lychee.toml`, and `brev/.lycheeignore` are untouched. Re-enabling automatic checks later is just a matter of restoring the original `on:` triggers and removing the `stages: [manual]` line.