### PR TITLE
CI: Fix git-signatures hook misclassifying signed commits as unsigned.

### DIFF
--- a/brev/test-git-signatures.bash
+++ b/brev/test-git-signatures.bash
@@ -97,11 +97,15 @@ for sha in $COMMIT_SHAS; do
     if git verify-commit "$sha" 2>/dev/null; then
         echo -e "${GREEN}✓${NC} $SHORT_SHA - $MESSAGE (signed)"
     else
-        # Check if it has a signature at all (even if we can't verify it)
-        if git log -1 --format="%G?" "$sha" 2>/dev/null | grep -q "^[GUX]"; then
-            # G = good, U = good but untrusted, X = good but expired
-            SIGNATURE_STATUS=$(git log -1 --format="%G?" "$sha" 2>/dev/null)
-            echo -e "${YELLOW}⚠${NC} $SHORT_SHA - $MESSAGE (signature present but unverifiable: $SIGNATURE_STATUS)"
+        # git verify-commit can fail even when the commit IS signed: SSH
+        # signatures cannot be verified unless gpg.ssh.allowedSignersFile is
+        # configured, and GPG signatures cannot be verified without the
+        # signer's public key. In both cases `git log --format=%G?` reports
+        # "N" (no signature), so it is not a reliable presence check here.
+        # Instead, look for a signature block directly in the commit object.
+        # CI performs the authoritative verification via the GitHub API.
+        if git cat-file -p "$sha" 2>/dev/null | sed '/^$/q' | grep -q "^gpgsig"; then
+            echo -e "${YELLOW}⚠${NC} $SHORT_SHA - $MESSAGE (signature present but not verifiable locally)"
         else
             echo -e "${RED}✗${NC} $SHORT_SHA - $MESSAGE (NOT signed)"
             UNSIGNED_COMMITS="$UNSIGNED_COMMITS"$'\n'"  - $SHORT_SHA: $MESSAGE"


### PR DESCRIPTION
Fixes #181.

## Problem

The `git-signatures` pre-push hook (`brev/test-git-signatures.bash`) reports **SSH-signed commits as `NOT signed`** when `gpg.ssh.allowedSignersFile` is not configured locally — blocking pushes of commits that are, in fact, properly signed (and that CI accepts).

## Root cause

When `git verify-commit` cannot verify a signature, the hook fell back to `git log --format=%G?` to check whether *any* signature was present:

```bash
if git log -1 --format="%G?" "$sha" | grep -q "^[GUX]"; then
```

But `%G?` returns `N` ("no signature") precisely in the cases where verification is impossible without extra local setup:

- **SSH** signatures when `gpg.ssh.allowedSignersFile` is not set, and
- **GPG** signatures when the signer's public key isn't in the local keyring.

So a genuinely signed commit becomes indistinguishable from an unsigned one and is failed as unsigned. CI is unaffected because it verifies through the GitHub API (`commit.verification.verified`), which is why the same commit passes CI but fails the local hook.

## Fix

Detect the signature by looking for the `gpgsig` header in the commit object itself, which is independent of any local verifier configuration:

```bash
if git cat-file -p "$sha" | sed '/^$/q' | grep -q "^gpgsig"; then
```

- The search is bounded to the commit-object **header** (`sed '/^$/q'` stops at the first blank line) so a `gpgsig` string in a commit *message* body cannot cause a false positive.
- `git verify-commit` is still tried first, so locally verifiable signatures continue to be reported as fully verified.
- This new presence check is a strict superset of the old `[GUX]` check (any commit with a `[GUX]` status necessarily carries a `gpgsig` header), so it does not weaken detection of truly unsigned commits.

## Testing

Verified against the same real SSH-signed commit, with `gpg.ssh.allowedSignersFile` unset (the issue's exact condition):

| | Result | Exit |
|---|---|---|
| **Before fix** | `✗ ... (NOT signed)` → ERROR | `1` |
| **After fix**  | `⚠ ... (signature present but not verifiable locally)` | `0` |

A genuinely unsigned commit is still correctly reported as `NOT signed` (exit `1`). `bash -n` passes.