### PR TITLE
Tutorials/stdpar: Pin stdexec to fix nvc++ internal compiler error in Lab 2.

### DIFF
--- a/tutorials/stdpar/brev/docker-recipe.py
+++ b/tutorials/stdpar/brev/docker-recipe.py
@@ -14,6 +14,14 @@ gcc_ver = '13'
 llvm_ver = '18'
 cmake_ver = '3.27.2'
 boost_ver = '1.75.0'
+# Pin stdexec to a commit that is known to compile with the nvc++ from NVHPC 24.3.
+# Newer stdexec revisions on `main` use constructs (e.g. the `__msplice_v` variable
+# template in `__typeinfo.hpp`) that crash the nvc++ 24.3 EDG front-end with a
+# catastrophic internal error, which breaks the Lab 2 senders & receivers exercise.
+# This commit (2026-01-08) is the most recent revision that still both compiles on
+# nvc++ 24.3 (multicore and gpu) and exposes the `stdexec::on(sch, sender)` API the
+# tutorial uses. Bump this together with `nvhpc_ver`.
+stdexec_commit = '433dc54f93ab503b5595c2c7c047c8e9b80b62bd'
 arch = platform.machine()
 
 Stage0 += baseimage(image=f'nvcr.io/nvidia/nvhpc:{nvhpc_ver}-devel-cuda{cuda_ver}-ubuntu{ubuntu_ver}')
@@ -114,7 +122,15 @@ Stage0 += shell(commands=[
   'git clone --depth=1 https://github.com/ericniebler/range-v3.git',
   'cp -r range-v3/include/* /usr/include/',
   'rm -rf range-v3',
-  'git clone --depth=1 https://github.com/nvidia/stdexec.git',
+  # NOTE: stdexec is pinned (see `stdexec_commit` above) because newer revisions
+  #       crash the nvc++ 24.3 front-end. Fetch just the pinned commit to keep the
+  #       checkout shallow.
+  'git init stdexec',
+  'cd stdexec',
+  'git remote add origin https://github.com/nvidia/stdexec.git',
+  f'git fetch --depth=1 origin {stdexec_commit}',
+  'git checkout FETCH_HEAD',
+  'cd -',
   'cp -r stdexec/include/* /usr/include/',
   'rm -rf stdexec',
 


### PR DESCRIPTION
## Summary

Lab 2 (`tutorials/stdpar/notebooks/cpp/lab2_heat`) Exercise 3 — **Senders & Receivers** — fails to compile with `nvc++` due to a catastrophic internal compiler error originating in the installed stdexec headers:

```
"/usr/include/exec/../stdexec/__detail/__typeinfo.hpp", line 256: internal error:
  assertion failed at: "func_def.cpp", line 1729 in scan_function_body
      extern decltype(__typeid_lookup(__mtypeid_key<_Id>())) __msplice_v;
                      ^
1 catastrophic error detected in the compilation of "solutions/exercise3.cpp".
```

This affects both `exercise3.cpp` (the template) and `solutions/exercise3.cpp`, in **both** `-stdpar=multicore` and `-stdpar=gpu` modes. `g++` and `clang++` are unaffected. The notebook tells students this exercise compiles and runs on all four compiler configurations, so the NVIDIA-compiler path is currently broken.

A minimal reproducer is just:

```cpp
#include <exec/static_thread_pool.hpp>   // nvc++ -std=c++23 -stdpar=multicore → ICE
```

## Root cause

`tutorials/stdpar/brev/docker-recipe.py` installs stdexec from an **unpinned** clone of `main`:

```python
git clone --depth=1 https://github.com/nvidia/stdexec.git
cp -r stdexec/include/* /usr/include/
```

`main` has since drifted to a revision whose `__typeinfo.hpp` uses an `extern decltype(...) __msplice_v;` construct that the `nvc++` 24.3 EDG front-end cannot parse, crashing the compiler. (The image is otherwise pinned to NVHPC `24.3` via `nvhpc_ver`.) Because the clone is unpinned, the tutorial silently breaks whenever upstream stdexec moves — the image built on 2026-06-18 already contains the broken revision.

## Fix

Pin stdexec to commit `433dc54f` (2026-01-08) and fetch just that commit:

```python
stdexec_commit = '433dc54f93ab503b5595c2c7c047c8e9b80b62bd'
...
'git init stdexec',
'cd stdexec',
'git remote add origin https://github.com/nvidia/stdexec.git',
f'git fetch --depth=1 origin {stdexec_commit}',
'git checkout FETCH_HEAD',
'cd -',
```

I bisected stdexec to choose this commit: it is the **most recent** revision that both (a) compiles cleanly under `nvc++` 24.3 in multicore and gpu modes, and (b) still exposes the `stdexec::on(sch, sender)` API the exercise uses. Revisions from 2026-01-09 onward break `-stdpar=multicore` with a different ICE (`BAD sptr in func_refsym` in `__spin_loop_pause.hpp`); the `gtc-2026` and `nvhpc-26.05` tags target newer SDKs and fail against 24.3. A comment on `stdexec_commit` notes it should be bumped together with `nvhpc_ver`.

## Validation

I rebuilt the tutorial image from the patched recipe and ran the exact notebook commands inside it (no workarounds). Energy output is byte-identical across all four compilers:

| Source | g++ | clang++ | nvc++ multicore | nvc++ gpu |
|---|---|---|---|---|
| `exercise3.cpp` (template) | compiles & runs, no energy (empty `iteration_step`, as designed) | ✅ | ✅ | ✅ |
| `solutions/exercise3.cpp` | `E = 0.0535212` | `0.0535212` | `0.0535212` | `0.0535212` |

I also re-ran the full Lab 1 (DAXPY, exercises 1–8) and Lab 2 (exercises 1–3) matrices — templates and solutions, all four compiler configurations — to confirm no regression. Everything else already passed and continues to pass; this stdexec pin is the only change needed. The Lab 2 solution Exercise 3 also runs correctly at the notebook's full problem size (`1024 16384 500`) on 4× L4 GPUs (~630 GB/s aggregate).

## Notes for reviewers

- `range-v3` is also cloned unpinned in the same recipe block. It is not used by the C++ `stdpar` notebooks (they use the patched libstdc++ `std::views::cartesian_product`), and it did not break in testing, so I left it alone to keep this PR focused — but it carries the same latent drift risk and may be worth pinning separately.
- The `stdpar` tutorial has no `test/test_notebooks.py` (unlike e.g. `accelerated-python`), even though `tutorials/stdpar/brev/test.bash` references one. That gap is why this ICE wasn't caught in CI; adding notebook execution tests for `stdpar` would prevent regressions like this, but is out of scope here.
