### PR TITLE
tutorial: mpi4py: fix broken f-string interpolation in example output

### DIFF
--- a/tutorials/accelerated-python/notebooks/distributed/60__mpi4py.ipynb
+++ b/tutorials/accelerated-python/notebooks/distributed/60__mpi4py.ipynb
@@ -89,7 +89,7 @@
     "name = MPI.Get_processor_name()\n",
     "pid = os.getpid()\n",
     "print(f\"Hello World! I am process {rank} of {size} on {name} \"\n",
-    "       \"with pid {pid}.\\n\")"
+    "       f\"with pid {pid}.\\n\")"
    ]
   },
   {
@@ -263,7 +263,7 @@
     "rank = comm.Get_rank()\n",
     "for r_id in range(comm.Get_size()):\n",
     "    if rank == r_id:\n",
-    "        print(f\"Hello from proc:\")\n",
+    "        print(f\"Hello from proc: {rank}\")\n",
     "comm.Barrier()\n",
     "print(f\"proc {rank} after barrier\")"
    ]
@@ -304,7 +304,7 @@
     "data = comm.scatter(data, root=0)\n",
     "assert data == (rank+1)**2\n",
     "\n",
-    "print(f\"data on rank %d is: {rank}, {data}\")"
+    "print(f\"data on rank {rank} is: {data}\")"
    ]
   },
   {
@@ -336,7 +336,7 @@
     "size = comm.Get_size()\n",
     "\n",
     "data = (rank+1)**2\n",
-    "print(f\"before gather, data on rank %d is: {rank}, {data}\")\n",
+    "print(f\"before gather, data on rank {rank} is: {data}\")\n",
     "\n",
     "comm.Barrier()\n",
     "data = comm.gather(data, root=0)\n",


### PR DESCRIPTION
## Summary

While testing the notebooks in the **PyHPC** and **CUDA Python** syllabi of the accelerated-python tutorial, I found four `print` statements in `notebooks/distributed/60__mpi4py.ipynb` that emit **incorrect output**. None of them raise an error — the notebook executes cleanly — but the printed text is wrong, which is confusing in a teaching notebook whose whole point is to show what each MPI collective produces.

All four are the same class of mistake: a malformed f-string where the interpolation never happens.

## Bugs fixed

| Script (cell) | Before | Printed (wrong) | After |
|---|---|---|---|
| `hello_world_with_ranks.py` | `print(f"… on {name} "`<br>`       "with pid {pid}.\n")` | `… with pid {pid}.` | add `f` to the continuation line |
| `barrier.py` | `print(f"Hello from proc:")` | `Hello from proc:` (no rank) | `print(f"Hello from proc: {rank}")` |
| `scatter.py` | `print(f"data on rank %d is: {rank}, {data}")` | `data on rank %d is: 2, 9` | `print(f"data on rank {rank} is: {data}")` |
| `gather.py` | `print(f"before gather, data on rank %d is: {rank}, {data}")` | `before gather, data on rank %d is: 3, 16` | `print(f"before gather, data on rank {rank} is: {data}")` |

Details:

- **`hello_world_with_ranks.py`** — the second line of the implicitly-concatenated string literal is a plain string (no `f`), so `{pid}` was never interpolated and the output read `with pid {pid}.` literally.
- **`barrier.py`** — `f"Hello from proc:"` is an f-string with no placeholder, so the rank was dropped. The fix prints the rank, matching the sibling line that already prints `proc {rank} after barrier`.
- **`scatter.py` / `gather.py`** — a stray printf-style `%d` was left inside an f-string. Since no `%` operator is applied, `%d` printed literally. The fix uses pure f-string interpolation, matching `gather.py`'s own correct line `f"data on rank: {rank} is: {data}"`.

## Verification

I executed the full notebook end-to-end (mpi4py 4.1.1, OpenMPI, 2–4 ranks) before and after the change. After the fix the affected cells print correctly:

```
# hello_world_with_ranks.py
Hello World! I am process 0 of 2 on <host> with pid 4094.

# barrier.py
Hello from proc: 3
Hello from proc: 1
...

# scatter.py        (rank -> (rank+1)**2)
data on rank 0 is: 1
data on rank 1 is: 4
data on rank 2 is: 9
data on rank 3 is: 16

# gather.py
before gather, data on rank 0 is: 1
...
data on rank: 0 is: [1, 4, 9, 16]
```

The whole notebook runs without errors or warnings, and the remaining cells (`send_recv*`, `reduce`, `compute_pi`, `compute_mandelbot`) are unchanged and continue to produce correct results.

The change is 4 lines (one per bug); no outputs or execution counts are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)