### PR TITLE
Tutorials/stdpar: Correct select benchmark memory-traffic accounting.

### DIFF
--- a/tutorials/stdpar/notebooks/cpp/lab1_select/exercise1.cpp
+++ b/tutorials/stdpar/notebooks/cpp/lab1_select/exercise1.cpp
@@ -101,7 +101,9 @@ void bench(std::vector<int>& v, Predicate&& predicate, std::vector<size_t>& inde
         select(v, predicate, index, w);
     }
     auto seconds = std::chrono::duration<double>(clk_t::now() - start).count(); // Duration in [s]
-    // Bandwith for a memcpy:
-    auto gigabytes = 2. * sizeof(int) * (double)v.size() * 1.e-9; // GB
+    // Effective memory traffic: read every element of `v` once and write the
+    // selected elements to `w`. (The `index` scratch array is not counted.)
+    auto selected = std::count_if(std::execution::par, v.begin(), v.end(), predicate);
+    auto gigabytes = sizeof(int) * ((double)v.size() + (double)selected) * 1.e-9; // GB
     std::cerr << "Problem size: " << gigabytes << " GB, Bandwidth [GB/s]: " << (gigabytes * (double)nit / seconds) << std::endl;
 }

--- a/tutorials/stdpar/notebooks/cpp/lab1_select/exercise2.cpp
+++ b/tutorials/stdpar/notebooks/cpp/lab1_select/exercise2.cpp
@@ -110,7 +110,9 @@ void bench(std::vector<int>& v, Predicate&& predicate, std::vector<size_t>& inde
         select(v, predicate, index, w);
     }
     auto seconds = std::chrono::duration<double>(clk_t::now() - start).count(); // Duration in [s]
-    // Bandwith for a memcpy:
-    auto gigabytes = 2. * sizeof(int) * (double)v.size() * 1.e-9; // GB
+    // Effective memory traffic: read every element of `v` once and write the
+    // selected elements to `w`. (The `index` scratch array is not counted.)
+    auto selected = std::count_if(std::execution::par, v.begin(), v.end(), predicate);
+    auto gigabytes = sizeof(int) * ((double)v.size() + (double)selected) * 1.e-9; // GB
     std::cerr << "Problem size: " << gigabytes << " GB, Bandwidth [GB/s]: " << (gigabytes * (double)nit / seconds) << std::endl;
 }

--- a/tutorials/stdpar/notebooks/cpp/lab1_select/solutions/copy_if.cpp
+++ b/tutorials/stdpar/notebooks/cpp/lab1_select/solutions/copy_if.cpp
@@ -100,7 +100,9 @@ void bench(std::vector<int>& v, Predicate&& predicate, std::vector<size_t>& inde
         select(v, predicate, index, w);
     }
     auto seconds = std::chrono::duration<double>(clk_t::now() - start).count(); // Duration in [s]
-    // Bandwith for a memcpy:
-    auto gigabytes = 2. * sizeof(int) * (double)v.size() * 1.e-9; // GB
+    // Effective memory traffic: read every element of `v` once and write the
+    // selected elements to `w`. (The `index` scratch array is not counted.)
+    auto selected = std::count_if(std::execution::par, v.begin(), v.end(), predicate);
+    auto gigabytes = sizeof(int) * ((double)v.size() + (double)selected) * 1.e-9; // GB
     std::cerr << "Problem size: " << gigabytes << " GB, Bandwidth [GB/s]: " << (gigabytes * (double)nit / seconds) << std::endl;
 }

--- a/tutorials/stdpar/notebooks/cpp/lab1_select/solutions/exercise1.cpp
+++ b/tutorials/stdpar/notebooks/cpp/lab1_select/solutions/exercise1.cpp
@@ -101,7 +101,9 @@ void bench(std::vector<int>& v, Predicate&& predicate, std::vector<size_t>& inde
         select(v, predicate, index, w);
     }
     auto seconds = std::chrono::duration<double>(clk_t::now() - start).count(); // Duration in [s]
-    // Bandwith for a memcpy:
-    auto gigabytes = 2. * sizeof(int) * (double)v.size() * 1.e-9; // GB
+    // Effective memory traffic: read every element of `v` once and write the
+    // selected elements to `w`. (The `index` scratch array is not counted.)
+    auto selected = std::count_if(std::execution::par, v.begin(), v.end(), predicate);
+    auto gigabytes = sizeof(int) * ((double)v.size() + (double)selected) * 1.e-9; // GB
     std::cerr << "Problem size: " << gigabytes << " GB, Bandwidth [GB/s]: " << (gigabytes * (double)nit / seconds) << std::endl;
 }

--- a/tutorials/stdpar/notebooks/cpp/lab1_select/solutions/exercise2.cpp
+++ b/tutorials/stdpar/notebooks/cpp/lab1_select/solutions/exercise2.cpp
@@ -110,7 +110,9 @@ void bench(std::vector<int>& v, Predicate&& predicate, std::vector<size_t>& inde
         select(v, predicate, index, w);
     }
     auto seconds = std::chrono::duration<double>(clk_t::now() - start).count(); // Duration in [s]
-    // Bandwith for a memcpy:
-    auto gigabytes = 2. * sizeof(int) * (double)v.size() * 1.e-9; // GB
+    // Effective memory traffic: read every element of `v` once and write the
+    // selected elements to `w`. (The `index` scratch array is not counted.)
+    auto selected = std::count_if(std::execution::par, v.begin(), v.end(), predicate);
+    auto gigabytes = sizeof(int) * ((double)v.size() + (double)selected) * 1.e-9; // GB
     std::cerr << "Problem size: " << gigabytes << " GB, Bandwidth [GB/s]: " << (gigabytes * (double)nit / seconds) << std::endl;
 }


### PR DESCRIPTION
## Summary

The `select` / `copy_if` benchmark in Lab 1 (`lab1_select`) reports an **effective memory bandwidth that exceeds the GPU's physical peak**, because its traffic model overcounts the bytes moved.

The benchmark models traffic as a full read **and** write of the input array:

```cpp
// Bandwith for a memcpy:
auto gigabytes = 2. * sizeof(int) * (double)v.size() * 1.e-9; // GB
```

i.e. it assumes `select` copies *all* `N` elements. But `select` only writes the elements that satisfy the predicate. For this lab's predicate (`x % 3 == 0` over `uniform[0, 100]`), **~33.7M of 100M** elements are selected, so the real useful traffic is `sizeof(int) * (N + selected) ≈ 0.535 GB`, not the modeled `0.8 GB` — about **1.5× too high**.

That inflation pushes the reported number past what the hardware can do. On an NVIDIA L4 (≈300 GB/s peak GDDR6), parallel `copy_if` reported **~375 GB/s** — physically impossible, which is a red flag for a teaching benchmark.

## Fix

Count the genuine traffic of a stream-compaction: read every element of `v` once, and write the selected elements to `w`.

```cpp
// Effective memory traffic: read every element of `v` once and write the
// selected elements to `w`. (The `index` scratch array is not counted.)
auto selected = std::count_if(std::execution::par, v.begin(), v.end(), predicate);
auto gigabytes = sizeof(int) * ((double)v.size() + (double)selected) * 1.e-9; // GB
```

`selected` is computed once, **outside the timed region**, so timing is unaffected. The `index` scratch array (which the notebook explicitly describes as "extra temporary storage that our implementation is allowed to use") is intentionally **not** counted, so the manual scan-based Exercise 2 honestly reports a lower effective bandwidth than `copy_if` rather than being credited for scratch traffic.

Applied identically to all five `lab1_select` sources (`exercise1.cpp`, `exercise2.cpp`, `solutions/exercise{1,2}.cpp`, `solutions/copy_if.cpp`), which shared the same benchmark block.

## Validation

Re-ran all five files across all four compiler configurations (g++, clang++, nvc++ multicore, nvc++ gpu) at the notebook size (N=100M). Correctness checks unchanged; reported `Problem size` is now `0.535 GB`, and **all reported bandwidths are below the L4's physical peak**:

| | before (GB/s) | after (GB/s) |
|---|---|---|
| `solutions/copy_if.cpp` — nvc++ gpu | **375** (> 300 peak ❌) | **249** ✅ |
| `solutions/exercise1.cpp` — nvc++ gpu | 214 | 142 |
| `solutions/exercise2.cpp` — nvc++ gpu | 80 | 53 |

The relative ordering across implementations is preserved; only the (previously impossible) absolute magnitudes are corrected.

## Notes

- Independent of the other two open stdpar PRs (the nvc++ stdexec pin and the notebook-text fixes); touches different files.
