### PR TITLE
std_par_cpp: fix slides 38, 39

### DIFF
--- a/tutorials/stdpar/slides/stdpar_cpp_tutorial__r6__2025_11_sc.pdf
+++ b/tutorials/stdpar/slides/stdpar_cpp_tutorial__r6__2025_11_sc.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b6a30b30178cfb2e8a58cd7b3fa277254ce57aacb45eda47133e1dbdb15cc333
-size 5715936
+oid sha256:65acacc5d1e0edb9b7eb4f5ffb3e7591292a04a6af86bc7021c73a005683cac9
+size 7672940

--- a/tutorials/stdpar/slides/stdpar_cpp_tutorial__r6__2025_11_sc.pptx
+++ b/tutorials/stdpar/slides/stdpar_cpp_tutorial__r6__2025_11_sc.pptx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b58229366bd27e590fd4d367669ba4cee6693c3b1b27239ea4a6c8ce7e1a1161
-size 68555543
+oid sha256:16f3e456fbafba88624ffbf146f397746ea5d3eb881b2329dabcf3d583e5b1fa
+size 21477238


### PR DESCRIPTION
The slides used "pointer" instead of "reference" when presenting lambda captures.

This PR replaces "pointer" with "reference" on slides 38 and 39.
