### PR TITLE
Upgrade docker image used in nvmath-python tutorials

### DIFF
--- a/.github/workflows/mirror-base-images.yml
+++ b/.github/workflows/mirror-base-images.yml
@@ -23,6 +23,8 @@ jobs:
         image:
           - source: pytorch/pytorch:2.9.0-cuda12.8-cudnn9-runtime
             target_name: pytorch-2.9.0-cuda12.8-cudnn9-runtime
+          - source: pytorch/pytorch:2.12.1-cuda13.2-cudnn9-runtime
+            target_name: pytorch-2.12.1-cuda13.2-cudnn9-runtime
           - source: nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu22.04
             target_name: nvidia-cuda-13.1.0-devel-ubuntu22.04
       fail-fast: false

--- a/tutorials/nvmath-python/brev/dockerfile
+++ b/tutorials/nvmath-python/brev/dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/nvidia/mirrors/pytorch-2.9.0-cuda12.8-cudnn9-runtime
+FROM pytorch/pytorch:2.12.1-cuda13.2-cudnn9-runtime
 
 ENV ACH_TUTORIAL=nvmath-python \
-    PIP_ROOT_USER_ACTION=ignore \
+    PIP_BREAK_SYSTEM_PACKAGES=1 \
     CUPY_CACHE_DIR=/tmp/cupy_cache \
     MPLCONFIGDIR=/tmp/matplotlib_cache
 
@@ -10,7 +10,7 @@ COPY tutorials/${ACH_TUTORIAL}/brev/requirements.txt /opt/requirements.txt
 
 RUN set -ex \
  && `# Install Python packages` \
-     && pip install --no-cache-dir --root-user-action=ignore -r /opt/requirements.txt \
+     && pip install --no-cache-dir -r /opt/requirements.txt \
      && rm -f /opt/requirements.txt \
  && `# Install system packages` \
      && apt-get update -y \

--- a/tutorials/nvmath-python/brev/requirements.txt
+++ b/tutorials/nvmath-python/brev/requirements.txt
@@ -1,19 +1,10 @@
-# Pin NVIDIA library versions to match PyTorch requirements
-nvidia-cublas-cu12==12.8.4.1
-nvidia-nvshmem-cu12==3.3.20
-nvidia-cuda-nvcc-cu12==12.8.*
-nvidia-cuda-nvrtc-cu12==12.8.*
-
-# CUDA
-cuda-python == 12.9.1 # cuda.{core, bindings}, numba.cuda
-
 # Scientific
 numpy
 scipy
 ssgetpy
-cupy-cuda12x
+cupy-cuda13x
 
-nvmath-python[cu12,dx,cpu,cu12-distributed]
+nvmath-python[cu13-distributed,cu13-dx,cpu]
 
 # Visualization
 matplotlib
@@ -28,6 +19,9 @@ jupyterlab-nvidia-nsight
 jupyterlab-execute-time
 ipywidgets
 ipykernel
+ipyparallel
+nbdistributed
 
 # MPI
+openmpi
 mpi4py

--- a/tutorials/nvmath-python/brev/requirements.txt
+++ b/tutorials/nvmath-python/brev/requirements.txt
@@ -1,10 +1,7 @@
 # Pin NVIDIA library versions to match PyTorch requirements from
 # pytorch:2.12.1-cuda13.2-cudnn9-runtime image.
-cuda-toolkit==13.2.*
-nvidia-cublas==13.4.0.1
+cuda-toolkit[cublas,nvrtc,nvjitlink]==13.2.1
 nvidia-nvshmem-cu13==3.4.5
-nvidia-cuda-nvrtc==13.2.*
-nvidia-nvjitlink==13.2.*
 
 # Scientific
 numpy

--- a/tutorials/nvmath-python/brev/requirements.txt
+++ b/tutorials/nvmath-python/brev/requirements.txt
@@ -1,3 +1,11 @@
+# Pin NVIDIA library versions to match PyTorch requirements from
+# pytorch:2.12.1-cuda13.2-cudnn9-runtime image.
+cuda-toolkit==13.2.*
+nvidia-cublas==13.4.0.1
+nvidia-nvshmem-cu13==3.4.5
+nvidia-cuda-nvrtc==13.2.*
+nvidia-nvjitlink==13.2.*
+
 # Scientific
 numpy
 scipy


### PR DESCRIPTION
Use PyTorch 2.12 with CTK 13.2.

Update dependency set so that latest nvmath-python is installed.

Correctly install mpi4py+MPI.

Add ipyparallel and nbdistributed to dependencies to be able to launch multiple processes with MPI or torch.distributed from inside the notebook.