### PR TITLE
Fix canonical notebook format for 07_ust nvmath-python tutorial

### DIFF
--- a/tutorials/nvmath-python/notebooks/07_ust.ipynb
+++ b/tutorials/nvmath-python/notebooks/07_ust.ipynb
@@ -676,6 +676,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": [],
+   "toc_visible": true
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -691,7 +697,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/nvmath-python/notebooks/07_ust_SOLUTION.ipynb
+++ b/tutorials/nvmath-python/notebooks/07_ust_SOLUTION.ipynb
@@ -166,6 +166,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": [],
+   "toc_visible": true
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -181,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What

Brings `tutorials/nvmath-python/notebooks/07_ust.ipynb` and `07_ust_SOLUTION.ipynb` into canonical notebook format, fixing the **Test Notebook Format** CI check which is currently failing on `main`.

## Why

These two notebooks (added in the UST chapter) were never in canonical format:

- Missing `metadata.accelerator` (`"GPU"`)
- Missing `metadata.colab` (`gpuType`/`provenance`/`toc_visible`)
- `metadata.language_info.version` pinned to `3.12.3` instead of the standard `3.11.7`

`brev/test-notebook-format.py` flags all three, so the push-triggered `Test Notebook Format` workflow fails on trunk. All 12 sibling notebooks in the same tutorial already carry the canonical metadata; these two were the only deviations.

## How

Ran `brev/test-notebook-format.py --fix` on the two files. The change is metadata-only — no cell content or outputs are touched. The full repo check now reports `✅ All 128 notebook(s) are in canonical format!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)