### PR TITLE
Fix dependency issue in nvmath-python tutorial container

### DIFF
--- a/tutorials/nvmath-python/brev/requirements.txt
+++ b/tutorials/nvmath-python/brev/requirements.txt
@@ -3,6 +3,8 @@
 cuda-toolkit[cublas,nvrtc,nvjitlink]==13.2.1
 nvidia-nvshmem-cu13==3.4.5
 
+mkl<2026
+
 # Scientific
 numpy
 scipy


### PR DESCRIPTION
nvmath-python < 1.0 requires MKL < 2026.