### PR TITLE
Update CUDA Tile tutorial for CUDA 13.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following interactive tutorials are available and can be used on [NVIDIA Bre
 
 | Content | Docker Compose | Brev Instance | Brev Provider |
 |---------|----------------|---------------|---------------|
-| [CUDA Tile Tutorial](tutorials/cuda-tile/README.md) | [docker-compose.yml](tutorials/cuda-tile/brev/docker-compose.yml) | 1xB300, 1xB200, or 1xRTXPro6000 | Any Blackwell provider; none have Flexible Ports yet |
+| [CUDA Tile Tutorial](tutorials/cuda-tile/README.md) | [docker-compose.yml](tutorials/cuda-tile/brev/docker-compose.yml) | 1xA10G or newer Ampere/Ada/Hopper/Blackwell GPU | A10G on AWS or any provider with Ampere-or-newer GPUs |
 | [CUDA C++ Tutorial](tutorials/cuda-cpp/README.md) | [docker-compose.yml](tutorials/cuda-cpp/brev/docker-compose.yml) | L40S, L4, or T4 | Crusoe or any other with Flexible Ports |
 | [Standard Parallelism Tutorial](tutorials/stdpar/README.md) | [docker-compose.yml](tutorials/stdpar/brev/docker-compose.yml) | 4xL4, 2xL4, 2xL40S, or 1x L40S | GCP, AWS, or any other with Flexible Ports and Linux 6.1.24+, 6.2.11+, or 6.3+ (for HMM) |
 | [Accelerated Python Tutorial](tutorials/accelerated-python/README.md) | [docker-compose.yml](tutorials/accelerated-python/brev/docker-compose.yml) | L40S, L4, or T4; 4xL4 or 2xL4 for distributed | Crusoe or any other with Flexible Ports |

--- a/tutorials/cuda-tile/README.md
+++ b/tutorials/cuda-tile/README.md
@@ -1,6 +1,6 @@
 # CUDA Tile Tutorial
 
-This tutorial teaches youthe CUDA Tile programming model and how to use cuTile Python, cuTile C++, and Tile IR.
+This tutorial teaches you the CUDA Tile programming model and how to use cuTile Python, cuTile C++, and Tile IR.
 
 You'll find the following content:
 
@@ -8,7 +8,7 @@ You'll find the following content:
 - [Docker Images](https://github.com/NVIDIA/accelerated-computing-hub/pkgs/container/cuda-tile-tutorial) and [Docker Compose files](./brev/docker-compose.yml) for creating Brev Launchables or running locally.
 
 Brev Launchables of this tutorial should use:
-- 1xB300, 1xB200, or 1xRTX Pro 6000 instances (a Blackwell GPU is required).
+- 1xA10G or newer Ampere, Ada, Hopper, or Blackwell GPU instances.
 
 ## Notebooks
 

--- a/tutorials/cuda-tile/brev/dockerfile
+++ b/tutorials/cuda-tile/brev/dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nvidia/mirrors/nvidia-cuda-13.1.0-devel-ubuntu22.04
+FROM nvidia/cuda:13.3.0-devel-ubuntu22.04
 
 ENV ACH_TUTORIAL=cuda-tile \
     PYTHON_VERSION=3.12 \
@@ -49,11 +49,6 @@ RUN curl -fsSL https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0xBA693236
  && ln -s /usr/local/bin/pip /usr/bin/pip \
  && rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED \
  && rm -rf /var/lib/apt/lists/*
-
-# Install PyTorch with CUDA 13.0 support.
-RUN pip install --no-cache-dir --root-user-action=ignore \
-    --index-url https://download.pytorch.org/whl/cu130 \
-    torch==2.10.0
 
 # Copy only requirements.txt first for better Docker layer caching.
 COPY tutorials/${ACH_TUTORIAL}/brev/requirements.txt /opt/requirements.txt

--- a/tutorials/cuda-tile/brev/requirements.txt
+++ b/tutorials/cuda-tile/brev/requirements.txt
@@ -17,12 +17,13 @@ jupyterlab-nvidia-nsight
 jupyterlab-execute-time
 
 # CUDA
-cuda-tile
-cuda-python == 13.*
-cupy-cuda13x == 13.6.0
-numba-cuda[cu13] == 0.20.0
-nvmath-python[cu13]
-cuda-cccl[test-cu13]
+cuda-tile[tileiras] == 1.4.0
+cuda-toolkit[nvcc,nvvm,tileiras] == 13.3.1
+cuda-python == 13.3.1
+cupy-cuda13x == 14.1.1
+numba == 0.66.0
+numba-cuda[cu13] == 0.30.4
+cuda-cccl[test-cu13] == 1.0.2
 
 # NVIDIA developer tools
 nvtx

--- a/tutorials/cuda-tile/brev/test.bash
+++ b/tutorials/cuda-tile/brev/test.bash
@@ -1,0 +1,37 @@
+#! /bin/bash
+#
+# Run tests for the cuda-tile tutorial.
+
+set -euo pipefail
+
+START_TIME=$(date +%s.%N)
+
+nvidia-smi
+
+TUTORIAL_ROOT=/accelerated-computing-hub/tutorials/cuda-tile
+
+if [ $# -gt 0 ]; then
+    echo "Running: $*"
+    "$@"
+else
+    NOTEBOOK="${TUTORIAL_ROOT}/notebooks/01__cutile_python_intro__vector_add.ipynb"
+    OUTPUT="/tmp/01__cutile_python_intro__vector_add.executed.ipynb"
+
+    echo "Running: jupyter nbconvert --execute ${NOTEBOOK}"
+    jupyter nbconvert \
+        --to notebook \
+        --execute "${NOTEBOOK}" \
+        --output "${OUTPUT}" \
+        --ExecutePreprocessor.timeout=900
+fi
+
+END_TIME=$(date +%s.%N)
+ELAPSED=$(awk "BEGIN {print $END_TIME - $START_TIME}")
+
+echo ""
+awk -v elapsed="$ELAPSED" 'BEGIN {
+    hours = int(elapsed / 3600)
+    minutes = int((elapsed % 3600) / 60)
+    seconds = elapsed % 60
+    printf "Elapsed time: %dh %dm %.3fs\n", hours, minutes, seconds
+}'

--- a/tutorials/cuda-tile/notebooks/01__cutile_python_intro__vector_add.ipynb
+++ b/tutorials/cuda-tile/notebooks/01__cutile_python_intro__vector_add.ipynb
@@ -22,8 +22,8 @@
     "cuTile Python requires:\n",
     "\n",
     "    - NVIDIA Kernel Driver R580 or later.\n",
-    "    - CUDA Toolkit 13.1 or later.\n",
-    "    - A Blackwell GPU (this restriction will be lifted in later releases).\n",
+    "    - CUDA Toolkit 13.3 or later.\n",
+    "    - An NVIDIA GPU with compute capability 8.x or newer.\n",
     "\n",
     "You can install cuTile Python via the PIP package `cuda-tile`."
    ]
@@ -38,9 +38,13 @@
     "import os\n",
     "\n",
     "if not os.getenv(\"BREV_ENV_ID\") and not os.path.exists(\"/accelerated-computing-hub-installed\"): # If not running in brev\n",
-    "  print(\"Installing PIP packages.\")\n",
-    "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
-    "  !pip install \"cuda-tile\" \"cupy-cuda13x\" > /dev/null 2>&1\n",
+    "  try:\n",
+    "    import cuda.tile\n",
+    "    import cupy\n",
+    "    from numba import cuda\n",
+    "  except ImportError:\n",
+    "    print(\"Installing PIP packages.\")\n",
+    "    !pip install --upgrade \"cuda-tile[tileiras]==1.4.0\" \"cuda-python==13.3.1\" \"cupy-cuda13x==14.1.1\" \"numba==0.66.0\" \"numba-cuda[cu13]==0.30.4\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()"
    ]
   },
@@ -166,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cuda.core.experimental import Device\n",
+    "from cuda.core import Device\n",
     "\n",
     "def get_peak_memory_bandwidth(device_id: int = 0):\n",
     "  dev = Device(device_id)\n",


### PR DESCRIPTION
## Summary
- update the CUDA Tile tutorial image to the CUDA 13.3.0 devel base
- pin the current CUDA Tile/CUDA Python stack: cuda-tile[tileiras] 1.4.0, cuda-toolkit 13.3.1, cuda-python 13.3.1, cupy-cuda13x 14.1.1, numba 0.66.0, numba-cuda[cu13] 0.30.4, cuda-cccl 1.0.2
- update the notebook docs for CUDA 13.3+ and compute capability 8.x+ GPUs, including A10G
- add a Brev test script that executes the CUDA Tile vector-add notebook

## Verification
- python3 brev/test-notebook-format.py tutorials/cuda-tile/notebooks/start.ipynb tutorials/cuda-tile/notebooks/01__cutile_python_intro__vector_add.ipynb
- git diff --check
- docker build -f tutorials/cuda-tile/brev/dockerfile -t ach-cuda-tile:cuda13.3 .
- local container import smoke test for cuda-tile, cuda-python, cuda-toolkit, cupy, numba, and numba-cuda
- Brev A10G g5.xlarge: built commit 1f479922510c22ef2a8dd0a5cfa9aaf65423257f into ach-cuda-tile:pr-test
- Brev A10G g5.xlarge: docker run --rm --gpus all ... /accelerated-computing-hub/tutorials/cuda-tile/brev/test.bash
  - NVIDIA A10G, driver 595.71.05, CUDA Version 13.3 from inside the container
  - cuda-tile 1.4.0, cuda-python 13.3.1, cupy 14.1.1, numba 0.66.0, numba-cuda 0.30.4
  - notebook executed successfully in 14.083s

Brev cleanup: all A10G Brev instances are deleted; `brev ls --json` returned `{"workspaces": null}`.


