### PR TITLE
Bind Brev services to all interfaces

### DIFF
--- a/tutorials/accelerated-python/brev/docker-compose.yml
+++ b/tutorials/accelerated-python/brev/docker-compose.yml
@@ -58,13 +58,13 @@ services:
       <<: *common-env
       ACH_PORT_FORWARDS: "8080:nsys:8080 8081:ncu:8081"
     ports:
-      - "127.0.0.1:8888:8888" # JupyterLab
+      - "0.0.0.0:8888:8888" # JupyterLab
   nsys:
     <<: [*gpu-config, *common-service, *persistent-service]
     image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2026.1.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
-      - "127.0.0.1:8080:8080" # HTTP
+      - "0.0.0.0:8080:8080" # HTTP
       - "0.0.0.0:3478:3478" # TURN
   ncu:
     <<: [*gpu-config, *common-service, *persistent-service]
@@ -75,7 +75,7 @@ services:
       HTTP_PORT: "8081"
       TURN_PORT: "3479"
     ports:
-      - "127.0.0.1:8081:8081" # HTTP
+      - "0.0.0.0:8081:8081" # HTTP
       - "0.0.0.0:3479:3479" # TURN
 
 volumes:

--- a/tutorials/cuda-cpp/brev/docker-compose.yml
+++ b/tutorials/cuda-cpp/brev/docker-compose.yml
@@ -56,13 +56,13 @@ services:
       <<: *common-env
       ACH_PORT_FORWARDS: "8080:nsys:8080 8081:ncu:8080"
     ports:
-      - "127.0.0.1:8888:8888" # JupyterLab
+      - "0.0.0.0:8888:8888" # JupyterLab
   nsys:
     <<: [*gpu-config, *common-service, *persistent-service]
     image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2026.1.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
-      - "127.0.0.1:8080:8080" # HTTP
+      - "0.0.0.0:8080:8080" # HTTP
       - "0.0.0.0:3478:3478" # TURN
   ncu:
     <<: [*gpu-config, *common-service, *persistent-service]
@@ -72,7 +72,7 @@ services:
       <<: *common-env
       TURN_PORT: "3479"
     ports:
-      - "127.0.0.1:8081:8080" # HTTP
+      - "0.0.0.0:8081:8080" # HTTP
       - "0.0.0.0:3479:3479" # TURN
 
 volumes:

--- a/tutorials/cuda-tile/brev/docker-compose.yml
+++ b/tutorials/cuda-tile/brev/docker-compose.yml
@@ -58,13 +58,13 @@ services:
       <<: *common-env
       ACH_PORT_FORWARDS: "8080:nsys:8080 8081:ncu:8080"
     ports:
-      - "127.0.0.1:8888:8888" # JupyterLab
+      - "0.0.0.0:8888:8888" # JupyterLab
   nsys:
     <<: [*gpu-config, *common-service, *persistent-service]
     image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2026.1.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
-      - "127.0.0.1:8080:8080" # HTTP
+      - "0.0.0.0:8080:8080" # HTTP
       - "0.0.0.0:3478:3478" # TURN
   ncu:
     <<: [*gpu-config, *common-service, *persistent-service]
@@ -74,7 +74,7 @@ services:
       <<: *common-env
       TURN_PORT: "3479"
     ports:
-      - "127.0.0.1:8081:8080" # HTTP
+      - "0.0.0.0:8081:8080" # HTTP
       - "0.0.0.0:3479:3479" # TURN
 
 volumes:

--- a/tutorials/floating-point-emulation/brev/docker-compose.yml
+++ b/tutorials/floating-point-emulation/brev/docker-compose.yml
@@ -54,14 +54,14 @@ services:
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "jupyter"]
     command: *default-jupyter-url
     ports:
-      - "127.0.0.1:8888:8888" # JupyterLab
+      - "0.0.0.0:8888:8888" # JupyterLab
   nsight:
     <<: [*gpu-config, *common-service, *persistent-service]
     image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2025.3.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
-      - "127.0.0.1:8080:8080" # HTTP
-      - "127.0.0.1:3478:3478" # TURN
+      - "0.0.0.0:8080:8080" # HTTP
+      - "0.0.0.0:3478:3478" # TURN
 
 volumes:
   accelerated-computing-hub:

--- a/tutorials/stdpar/brev/docker-compose.yml
+++ b/tutorials/stdpar/brev/docker-compose.yml
@@ -57,13 +57,13 @@ services:
       <<: *common-env
       ACH_PORT_FORWARDS: "8080:nsys:8080 8081:ncu:8080"
     ports:
-      - "127.0.0.1:8888:8888" # JupyterLab
+      - "0.0.0.0:8888:8888" # JupyterLab
   nsys:
     <<: [*gpu-config, *common-service, *persistent-service]
     image: nvcr.io/nvidia/devtools/nsight-streamer-nsys:2026.1.1
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "nsight"]
     ports:
-      - "127.0.0.1:8080:8080" # HTTP
+      - "0.0.0.0:8080:8080" # HTTP
       - "0.0.0.0:3478:3478" # TURN
   ncu:
     <<: [*gpu-config, *common-service, *persistent-service]
@@ -73,7 +73,7 @@ services:
       <<: *common-env
       TURN_PORT: "3479"
     ports:
-      - "127.0.0.1:8081:8080" # HTTP
+      - "0.0.0.0:8081:8080" # HTTP
       - "0.0.0.0:3479:3479" # TURN
 
 volumes:

--- a/tutorials/warp/brev/docker-compose.yml
+++ b/tutorials/warp/brev/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     entrypoint: ["/accelerated-computing-hub/brev/entrypoint.bash", "jupyter"]
     command: *default-jupyter-url
     ports:
-      - "127.0.0.1:8888:8888" # JupyterLab
+      - "0.0.0.0:8888:8888" # JupyterLab
 
 volumes:
   accelerated-computing-hub:


### PR DESCRIPTION
## Summary

- bind JupyterLab and Nsight HTTP ports to `0.0.0.0` in every ACH Brev Docker Compose file
- update the remaining TURN binding in the floating-point emulation tutorial
- support the updated Brev backend networking requirements

## Validation

- `docker compose -f <file> config --quiet` for all seven Brev Compose files
- confirmed no `127.0.0.1` bindings remain in the Brev Compose files
- `git diff --check`