### PR TITLE
Fix Jupyter Nsight service proxies

### DIFF
--- a/brev/entrypoint-jupyter-user.bash
+++ b/brev/entrypoint-jupyter-user.bash
@@ -6,6 +6,12 @@ set -euo pipefail
 
 export HOME="${ACH_TARGET_HOME}"
 
+if [ -n "${ACH_PORT_FORWARDS:-}" ] && ! command -v socat &> /dev/null; then
+  echo "Error: ACH_PORT_FORWARDS is configured, but socat is not installed." >&2
+  echo "Install socat in the tutorial image to enable Jupyter service proxies." >&2
+  exit 1
+fi
+
 # Generate JupyterLab user settings
 /accelerated-computing-hub/brev/jupyter-generate-settings.bash
 
@@ -13,7 +19,7 @@ mkdir -p /accelerated-computing-hub/logs
 
 # Forward ports from other Docker Compose services to localhost so that
 # jupyter-server-proxy can reach them (it only proxies to localhost).
-if command -v socat &> /dev/null; then
+if [ -n "${ACH_PORT_FORWARDS:-}" ]; then
   for FORWARD in ${ACH_PORT_FORWARDS:-}; do
     LOCAL_PORT="${FORWARD%%:*}"
     REMOTE="${FORWARD#*:}"

--- a/tutorials/cuda-cpp/brev/dockerfile
+++ b/tutorials/cuda-cpp/brev/dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -y \
     gnupg \
     gosu \
     libglib2.0-0 \
+    socat \
     sudo \
     ffmpeg \
  && apt-get clean -y \

--- a/tutorials/cuda-tile/brev/dockerfile
+++ b/tutorials/cuda-tile/brev/dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update -y \
     lsb-release \
     gosu \
     libglib2.0-0 \
+    socat \
     sudo \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/*

--- a/tutorials/nvmath-python/brev/dockerfile
+++ b/tutorials/nvmath-python/brev/dockerfile
@@ -14,7 +14,7 @@ RUN set -ex \
      && rm -f /opt/requirements.txt \
  && `# Install system packages` \
      && apt-get update -y \
-     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git-lfs gosu sudo \
+     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git-lfs gosu socat sudo \
      && apt-get clean -y \
      && rm -rf /var/lib/apt/lists/*
 

--- a/tutorials/stdpar/brev/docker-recipe.py
+++ b/tutorials/stdpar/brev/docker-recipe.py
@@ -76,7 +76,7 @@ Stage0 += packages(ospackages=[
   'curl', 'wget', 'zip', 'bc',
   'nginx', 'openssh-client',
   'libnuma1',  'numactl',
-  'gosu', 'sudo',
+  'gosu', 'socat', 'sudo',
 ])
 Stage0 += boost(version=boost_ver) # Required for AdaptiveCpp
 


### PR DESCRIPTION
## Summary

- install `socat` in every tutorial image that configures `ACH_PORT_FORWARDS`
- fail Jupyter startup immediately with an actionable error when port forwards are configured without `socat`
- restore the `/nsys/` and `/ncu/` named proxy paths for CUDA C++, CUDA Tile, nvmath-python, and stdpar

## Root cause

The shared Jupyter entrypoint silently skipped creation of its localhost forwarders when `socat` was unavailable. `jupyter-server-proxy` then received browser requests normally but failed to connect to `localhost:8080` and `localhost:8081`, returning HTTP 500. Direct Nsight service URLs continued to work because they bypassed those missing listeners.

This was reproduced on Brev node `scipy-rtx-pro-6000-4576fe`: Docker service connections succeeded while both local forwarding ports returned `ECONNREFUSED`.

## Validation

- `bash -n brev/entrypoint-jupyter-user.bash`
- missing-`socat` container test confirms immediate exit 1 and actionable error
- `docker buildx build --check` for CUDA C++, CUDA Tile, nvmath-python, and generated stdpar Dockerfiles
- HPCCM stdpar generation includes `socat`
- `docker compose config --quiet` for all Brev Compose files
- repository pre-commit and manual hooks for changed files
- commit signature hook