### PR TITLE
Format notebooks

### DIFF
--- a/tutorials/nvmath-python/notebooks/01_kernel_fusion.ipynb
+++ b/tutorials/nvmath-python/notebooks/01_kernel_fusion.ipynb
@@ -614,7 +614,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/nvmath-python/notebooks/02_mem_exec_spaces.ipynb
+++ b/tutorials/nvmath-python/notebooks/02_mem_exec_spaces.ipynb
@@ -412,7 +412,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/nvmath-python/notebooks/03_stateful_api.ipynb
+++ b/tutorials/nvmath-python/notebooks/03_stateful_api.ipynb
@@ -526,7 +526,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/nvmath-python/notebooks/06_sparse_solver.ipynb
+++ b/tutorials/nvmath-python/notebooks/06_sparse_solver.ipynb
@@ -451,7 +451,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/nvmath-python/notebooks/06_sparse_solver_SOLUTION.ipynb
+++ b/tutorials/nvmath-python/notebooks/06_sparse_solver_SOLUTION.ipynb
@@ -167,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/nvmath-python/notebooks/07_ust.ipynb
+++ b/tutorials/nvmath-python/notebooks/07_ust.ipynb
@@ -697,7 +697,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/nvmath-python/notebooks/07_ust_SOLUTION.ipynb
+++ b/tutorials/nvmath-python/notebooks/07_ust_SOLUTION.ipynb
@@ -203,7 +203,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Currently CI is failing on `main`. This PR runs `python3 brev/test-notebook-format.py --fix` to correct the failures.
