### PR TITLE
Avoid workstation clone in CSCS launcher

### DIFF
--- a/docs/cscs.md
+++ b/docs/cscs.md
@@ -93,11 +93,12 @@ From the workstation, start and connect with one command:
 curl -fsSL https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/event/2026-07-cscs-summer-school/tutorials/pyhpc/brev/cscs-run-tutorial.bash | bash
 ```
 
-On its first run, the helper checks out the event branch in
-`${HOME}/accelerated-computing-hub`. It reads the CSCS username from the signed
-SSH certificate and uses the user's default Slurm account. It reuses one Daint
-SSH connection for the launch and compute-node tunnel; if the certificate
-expired, it runs `cscs-key sign` and retries once.
+The helper downloads the three small helper scripts to a temporary directory;
+it does not clone the repository on the workstation. It reads the CSCS username
+from the signed SSH certificate and uses the user's primary CSCS project as the
+Slurm account. It reuses one Daint SSH connection for the launch and
+compute-node tunnel; if the certificate expired, it runs `cscs-key sign` and
+retries once.
 The Daint-side launcher:
 
 - clones the event branch when `$SCRATCH/accelerated-computing-hub` is absent;
@@ -129,7 +130,8 @@ To launch on a Daint login node without the end-to-end helper, copy or download
 After it reports a node, run the workstation-side connection helper:
 
 ```bash
-cd "${HOME}/accelerated-computing-hub/tutorials/pyhpc/brev"
+curl -fsSLO https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/event/2026-07-cscs-summer-school/tutorials/pyhpc/brev/cscs-connect-tutorial.bash
+chmod +x cscs-connect-tutorial.bash
 ./cscs-connect-tutorial.bash nidXXXXXX
 ```
 

--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -13,7 +13,7 @@ web-service job, waits until all three services are ready, prints the job and
 node IDs, and exits.
 
 Options:
-  --account ACCOUNT      Override the user's default Slurm account
+  --account ACCOUNT      Override the user's primary CSCS project
   --repo PATH            Checkout path (default: $SCRATCH/accelerated-computing-hub)
   --branch BRANCH        Release and new-checkout branch
                          (default: event/2026-07-cscs-summer-school)
@@ -265,6 +265,13 @@ login_main() {
     case "${start_timeout}" in
         ''|*[!0-9]*) echo "Error: --start-timeout must be an integer." >&2; return 2 ;;
     esac
+    if [ -z "${account}" ]; then
+        if ! account=$(id -gn "${USER}") || [ -z "${account}" ]; then
+            echo "Error: could not discover the primary CSCS project; use --account." >&2
+            return 2
+        fi
+    fi
+    echo "Using CSCS Slurm account ${account}."
 
     prepare_checkout "${repo}" "${branch}"
     echo "Using checkout branch ${CHECKOUT_BRANCH} with release assets from ${branch}."
@@ -300,9 +307,7 @@ login_main() {
         "--output=${state_dir}/slurm-%j.log"
         "--export=ALL,ACH_REPO=${repo},ACH_RUNTIME_REPO=${runtime_repo},ACH_STATE=${state_dir},ACH_RELEASE_BRANCH=${branch}"
     )
-    if [ -n "${account}" ]; then
-        sbatch_args+=(--account="${account}")
-    fi
+    sbatch_args+=(--account="${account}")
 
     local job_id
     job_id=$(sbatch "${sbatch_args[@]}" "${batch_script}" --batch)

--- a/tutorials/pyhpc/brev/cscs-run-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-run-tutorial.bash
@@ -44,42 +44,41 @@ if [ "${1:-}" = -h ] || [ "${1:-}" = --help ]; then
     exit 0
 fi
 
-bootstrap_workstation_checkout() {
+bootstrap_streamed_helpers() {
     local branch=${ACH_BRANCH:-event/2026-07-cscs-summer-school}
-    local checkout=${ACH_WORKSTATION_REPO:-${HOME:?HOME is not set}/accelerated-computing-hub}
+    local base_url=${ACH_CSCS_HELPER_BASE_URL:-https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/${branch}/tutorials/pyhpc/brev}
+    local helper_dir
+    helper_dir=$(mktemp -d "${TMPDIR:-/tmp}/ach-cscs-helpers.XXXXXX")
+
+    cleanup_downloads() {
+        rm -f "${helper_dir}/cscs-run-tutorial.bash" \
+            "${helper_dir}/cscs-launch-tutorial.bash" \
+            "${helper_dir}/cscs-connect-tutorial.bash"
+        rmdir "${helper_dir}" >/dev/null 2>&1 || true
+    }
+    trap cleanup_downloads EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
 
     [ -t 0 ] || cat >/dev/null
-    if [ ! -e "${checkout}" ]; then
-        git clone --depth 1 --branch "${branch}" \
-            https://github.com/NVIDIA/accelerated-computing-hub.git \
-            "${checkout}"
-    elif ! git -C "${checkout}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        echo "Error: ${checkout} exists but is not a Git checkout." >&2
-        exit 1
-    elif [ "$(git -C "${checkout}" branch --show-current)" != "${branch}" ]; then
-        echo "Error: ${checkout} must be on ${branch}." >&2
-        exit 1
-    elif [ -n "$(git -C "${checkout}" status --porcelain=v1 --untracked-files=all)" ]; then
-        echo "Error: ${checkout} has uncommitted changes." >&2
-        exit 1
-    else
-        git -C "${checkout}" pull --ff-only origin "${branch}"
-    fi
-
-    local runner="${checkout}/tutorials/pyhpc/brev/cscs-run-tutorial.bash"
-    if [ ! -x "${runner}" ]; then
-        echo "Error: ${checkout} does not contain the ${branch} web helper." >&2
-        exit 1
-    fi
+    local helper
+    for helper in cscs-run-tutorial.bash cscs-launch-tutorial.bash \
+        cscs-connect-tutorial.bash; do
+        curl --fail --location --retry 3 --silent --show-error \
+            "${base_url}/${helper}" --output "${helper_dir}/${helper}"
+        chmod 700 "${helper_dir}/${helper}"
+    done
     if ! { exec 3</dev/tty; } 2>/dev/null; then
         echo "Error: run this command from an interactive terminal." >&2
         exit 1
     fi
-    exec "${runner}" "$@" <&3 3<&-
+    local status=0
+    "${helper_dir}/cscs-run-tutorial.bash" "$@" <&3 3<&- || status=$?
+    exit "${status}"
 }
 
 if [ -z "${BASH_SOURCE[0]:-}" ]; then
-    bootstrap_workstation_checkout "$@"
+    bootstrap_streamed_helpers "$@"
 fi
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)


### PR DESCRIPTION
## Summary
- download the three CSCS helpers into a temporary workstation directory instead of cloning the repository
- discover the user primary CSCS project with `id -gn` on Daint and always pass it to `sbatch --account`
- update the standalone connection instructions so they do not require a workstation checkout

## Validation
- Bash syntax, ShellCheck, and diff checks pass
- streamed helper execution leaves no workstation checkout or temporary files
- real Daint reports `course_00432` primary project as `summerschool-course2026-cscs`
- real Daint `sbatch --test-only` succeeds with the discovered project