### PR TITLE
Use HTTP for CSCS web services

### DIFF
--- a/docs/cscs.md
+++ b/docs/cscs.md
@@ -106,17 +106,16 @@ The Daint-side launcher:
   `main` and is completely clean, including untracked files; and
 - leaves any modified or non-`main` checkout unchanged.
 
-It submits the 10-hour job, waits until all three HTTPS services report ready,
+It submits the 10-hour job, waits until all three web services report ready,
 prints `CSCS_WEB_JOB_ID` and `CSCS_WEB_NODE`, and exits. The workstation helper
 then opens all five forwards and leaves the user in a shell on the allocated
 compute node. There is no `tail` process to interrupt.
 
-Keep the compute-node shell open and visit these URLs. Each uses a job-local
-self-signed certificate, so the browser asks for confirmation once per URL.
+Keep the compute-node shell open and visit these URLs:
 
-- JupyterLab: <https://127.0.0.1:8888>
-- Nsight Systems: <https://127.0.0.1:8080>
-- Nsight Compute: <https://127.0.0.1:8081>
+- JupyterLab: <http://127.0.0.1:8888>
+- Nsight Systems: <http://127.0.0.1:8080>
+- Nsight Compute: <http://127.0.0.1:8081>
 
 ### Run the launch and connection separately
 
@@ -140,10 +139,10 @@ the user in a shell on `nidXXXXXX`. Exiting the shell closes the browser access
 but does not stop the Slurm job. Re-run the connection script to reconnect.
 
 The selected local Jupyter port and the four fixed Streamer ports must be free.
-Ports 8888 (the Jupyter default), 8080, and 8081 carry HTTPS and WebSocket
+Ports 8888 (the Jupyter default), 8080, and 8081 carry HTTP and WebSocket
 signaling; ports 3478 and 3479 carry the two Streamers' WebRTC media and input
-over TURN/TCP. Forwarding only the HTTPS ports displays the pages but does not
-provide working Streamer desktops. If only local port 8888 is already in use,
+over TURN/TCP. Forwarding only the three HTTP ports displays the pages but does
+not provide working Streamer desktops. If only local port 8888 is already in use,
 set `ACH_JUPYTER_LOCAL_PORT` before running either workstation helper; the
 helper prints the resulting JupyterLab URL. The helper keeps the four Streamer
 ports fixed, and its TURN URLs advertise ports 3478 and 3479 to the browser.
@@ -154,7 +153,7 @@ Because the media is TCP inside SSH's TCP connection, packet loss can cause
 head-of-line stalls. A stable wired connection is recommended, and keeping only
 one Streamer tab active reduces bandwidth.
 
-The web applications have no password. Their HTTPS listeners bind only to
+The web applications have no password. Their HTTP listeners bind only to
 compute-node loopback, and the TURN services require random job credentials.
 Access is therefore expected only through the SSH connection.
 
@@ -167,8 +166,8 @@ scancel --full --signal=TERM JOB_ID
 ```
 
 The job stops automatically after 10 hours. The full-job `TERM` above gives
-the helper time to remove its containers, private TLS material, and
-node-local image stores while leaving student work in the checkout untouched.
+the helper time to remove its containers and node-local image stores while
+leaving student work in the checkout untouched.
 
 ## Run tests
 

--- a/tutorials/pyhpc/brev/cscs-connect-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-connect-tutorial.bash
@@ -165,10 +165,10 @@ else
 fi
 
 cat <<EOF
-The HTTPS services are available while this SSH connection remains open:
-  JupyterLab:     https://127.0.0.1:${jupyter_local_port}
-  Nsight Systems: https://127.0.0.1:8080
-  Nsight Compute: https://127.0.0.1:8081
+The web services are available while this SSH connection remains open:
+  JupyterLab:     http://127.0.0.1:${jupyter_local_port}
+  Nsight Systems: http://127.0.0.1:8080
+  Nsight Compute: http://127.0.0.1:8081
 EOF
 
 target="${user}@${node}"

--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -370,30 +370,14 @@ if [ ! -x "${COMPOSE}" ]; then
         'podman-compose==1.6.0'
 fi
 
-TLS_HOST_DIR="${RUN_STATE}/tls"
-TLS_CONTAINER_DIR="/run/ach-tls"
-rm -rf "${TLS_HOST_DIR}"
-mkdir -m 700 "${TLS_HOST_DIR}"
-openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
-    -keyout "${TLS_HOST_DIR}/localhost.key" \
-    -out "${TLS_HOST_DIR}/localhost.crt" \
-    -subj "/CN=localhost" \
-    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
-    >/dev/null 2>&1
-chmod 600 "${TLS_HOST_DIR}/localhost.key" "${TLS_HOST_DIR}/localhost.crt"
-
 TURN_USERNAME="turn_$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9' | head -c 16)"
 TURN_PASSWORD="$(openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c 32)"
 
 export ACH_PODMAN_HOST_NETWORK=1
 export ACH_PODMAN_NOTEBOOKS_ROOT="${ACH_REPO}/tutorials/pyhpc/notebooks"
-export JUPYTER_HTTPS_CERT="${TLS_CONTAINER_DIR}/localhost.crt"
-export JUPYTER_HTTPS_KEY="${TLS_CONTAINER_DIR}/localhost.key"
 export JUPYTER_HOST=127.0.0.1
-export NSYS_HTTP_URL=https://127.0.0.1:8080
-export SELKIES_ENABLE_HTTPS=true
-export SELKIES_HTTPS_CERT="${TLS_CONTAINER_DIR}/localhost.crt"
-export SELKIES_HTTPS_KEY="${TLS_CONTAINER_DIR}/localhost.key"
+export NSYS_HTTP_URL=http://127.0.0.1:8080
+export SELKIES_ENABLE_HTTPS=false
 
 "${VENV}/bin/python" "${ACH_RUNTIME_REPO}/brev/prepare-podman-compose.py" \
     "${SOURCE_COMPOSE}" "${PODMAN_COMPOSE}" "${ACH_RUNTIME_REPO}" 1
@@ -449,7 +433,6 @@ cleanup() {
     for store in main nsys ncu; do
         clean_store "${store}"
     done
-    rm -rf "${TLS_HOST_DIR}"
     podman unshare rm -rf "${JOB_ROOT}" >/dev/null 2>&1 || true
     exit "${status}"
 }
@@ -492,7 +475,6 @@ start_service() {
             -f "${PODMAN_COMPOSE}" \
             run --rm --no-deps -T \
             -e "TURN_USERNAME=${TURN_USERNAME}" -e "TURN_PASSWORD=${TURN_PASSWORD}" \
-            -v "${TLS_HOST_DIR}:${TLS_CONTAINER_DIR}:ro" \
             "${service}"
     ) >"${log}" 2>&1 &
     local pid=$!
@@ -501,7 +483,7 @@ start_service() {
 
     local deadline=$((SECONDS + 300))
     while [ "${SECONDS}" -lt "${deadline}" ]; do
-        if curl --fail --insecure --silent \
+        if curl --fail --silent \
             --connect-timeout 1 --max-time 2 "${url}" >/dev/null 2>&1; then
             echo "${service} is ready"
             return 0
@@ -517,9 +499,9 @@ start_service() {
     return 1
 }
 
-start_service jupyter main https://127.0.0.1:8888/api/status
-start_service nsys nsys https://127.0.0.1:8080/health
-start_service ncu ncu https://127.0.0.1:8081/health
+start_service jupyter main http://127.0.0.1:8888/api/status
+start_service nsys nsys http://127.0.0.1:8080/health
+start_service ncu ncu http://127.0.0.1:8081/health
 
 echo "READY node=$(hostname -s)"
 echo "Logs: ${RUN_STATE}/{jupyter,nsys,ncu}.log"


### PR DESCRIPTION
## Summary

- serve JupyterLab, Nsight Systems, and Nsight Compute over HTTP inside the encrypted SSH tunnel
- remove job-local self-signed certificate generation and TLS mounts
- set `SELKIES_ENABLE_HTTPS=false`, which restores the Nsight Systems and Nsight Compute JupyterLab launcher tiles
- update readiness checks, printed URLs, and CSCS documentation for HTTP

The services remain bound to compute-node loopback and are reachable only through the authenticated SSH forwards.

## Root cause

`brev/jupyter-server-config.py` registers the `nsys` and `ncu` ServerProxy launcher entries only when Selkies HTTPS is disabled. The CSCS launcher set `SELKIES_ENABLE_HTTPS=true`, so both tiles disappeared; the plugin itself was present.

## Validation

Validated the exact resulting tree live on Daint in Slurm job `4270484` (node `nid006551`):

- JupyterLab: HTTP 200
- Nsight Systems: HTTP 200
- Nsight Compute: HTTP 200
- Jupyter proxy routes `/nsys/` and `/ncu/`: HTTP 200
- `/server-proxy/servers-info`: both `Nsight Systems` and `Nsight Compute` enabled
- `bash -n`: all three CSCS helpers
- ShellCheck: all three CSCS helpers
- `git diff --check`: clean

The validation job and its temporary scratch state were removed afterward.
