### PR TITLE
Avoid CSCS compute host-key prompt

### DIFF
--- a/tutorials/pyhpc/brev/cscs-connect-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-connect-tutorial.bash
@@ -145,6 +145,7 @@ ssh_args=(
     -i "${ssh_key}"
     -o IdentitiesOnly=yes
     -o ExitOnForwardFailure=yes
+    -o StrictHostKeyChecking=accept-new
     -o ServerAliveInterval=30
     -o ServerAliveCountMax=6
     -L "127.0.0.1:${jupyter_local_port}:127.0.0.1:8888"


### PR DESCRIPTION
## Summary

Automatically accept a previously unseen CSCS compute-node host key during the final SSH hop. This removes the interactive pre-authentication prompt that can outlive sshd's login grace period and close the multiplexed proxy stream. Changed host keys are still rejected.

## Validation

Validated against the still-running user allocation `4270667` on `nid005529`:

- connected through the final compute-node SSH hop
- established all five forwards
- JupyterLab returned HTTP 200 through the forwarded port
- Nsight Systems returned HTTP 200 through the forwarded port
- Nsight Compute returned HTTP 200 through the forwarded port
- `bash -n`, ShellCheck, and `git diff --check` pass

The allocation and all three services were healthy; no relaunch is required.
