### PR TITLE
Fix streamed CSCS runner and update clean checkouts

### DIFF
--- a/docs/cscs.md
+++ b/docs/cscs.md
@@ -102,9 +102,8 @@ retries once.
 The Daint-side launcher:
 
 - clones the event branch when `$SCRATCH/accelerated-computing-hub` is absent;
-- updates an existing checkout to the event branch only when it starts on
-  `main` and is completely clean, including untracked files; and
-- leaves any modified or non-`main` checkout unchanged.
+- switches any existing clean branch to the event branch and updates it; and
+- leaves a dirty checkout unchanged, including when it has untracked files.
 
 It submits the 10-hour job, waits until all three web services report ready,
 prints `CSCS_WEB_JOB_ID` and `CSCS_WEB_NODE`, and exits. The workstation helper

--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -57,28 +57,30 @@ prepare_checkout() {
             return 1
         fi
 
-        if [ "${branch}" = main ] && [ -z "${status}" ]; then
+        if [ -z "${status}" ]; then
             local remote_ref="refs/remotes/origin/${requested_branch}"
-            echo "Updating the clean main checkout to ${requested_branch} in ${repo}..."
+            echo "Updating the clean checkout to ${requested_branch} in ${repo} (current=${branch})..."
             git -C "${repo}" fetch origin \
                 "+refs/heads/${requested_branch}:${remote_ref}"
-            if [ "${requested_branch}" = main ]; then
-                git -C "${repo}" merge --ff-only "${remote_ref}"
-            elif git -C "${repo}" show-ref --verify --quiet \
+            if git -C "${repo}" show-ref --verify --quiet \
                 "refs/heads/${requested_branch}"; then
-                if ! git -C "${repo}" merge-base --is-ancestor \
+                if git -C "${repo}" merge-base --is-ancestor \
                     "refs/heads/${requested_branch}" "${remote_ref}"; then
+                    git -C "${repo}" switch "${requested_branch}"
+                    git -C "${repo}" merge --ff-only "${remote_ref}"
+                elif git -C "${repo}" merge-base --is-ancestor \
+                    "${remote_ref}" "refs/heads/${requested_branch}"; then
+                    git -C "${repo}" switch "${requested_branch}"
+                else
                     echo "Error: local ${requested_branch} cannot fast-forward to origin/${requested_branch}." >&2
-                    echo "The checkout is still on main; resolve it manually or use a different --repo path." >&2
+                    echo "The checkout remains on ${branch}; resolve it manually or use a different --repo path." >&2
                     return 1
                 fi
-                git -C "${repo}" switch "${requested_branch}"
-                git -C "${repo}" merge --ff-only "${remote_ref}"
             else
                 git -C "${repo}" switch -c "${requested_branch}" "${remote_ref}"
             fi
         else
-            echo "Leaving the existing checkout unchanged (branch=${branch}; only clean main is updated)."
+            echo "Leaving the dirty checkout unchanged (branch=${branch})."
         fi
     fi
 

--- a/tutorials/pyhpc/brev/cscs-run-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-run-tutorial.bash
@@ -77,7 +77,7 @@ bootstrap_streamed_helpers() {
     exit "${status}"
 }
 
-if [ -z "${BASH_SOURCE[0]:-}" ]; then
+if [ ! -f "${BASH_SOURCE[0]:-}" ]; then
     bootstrap_streamed_helpers "$@"
 fi
 


### PR DESCRIPTION
## Summary

- Treat a non-regular `BASH_SOURCE[0]` as a streamed runner invocation, so both `curl ... | bash` and `bash <(curl ...)` bootstrap the sibling helpers.
- Switch an existing clean Daint checkout to the requested event branch and fast-forward it, regardless of its current branch.
- Leave a dirty checkout unchanged, including when it contains untracked files.
- Update the CSCS deployment documentation to describe this behavior.

A Bash process substitution exposes the script as a FIFO such as `/dev/fd/63` (reported as `/proc/<pid>/fd/63` on some systems). The old empty-source check therefore treated the FIFO directory as the script directory and failed while looking for sibling helpers.

Checkout updates remain fast-forward-only. A clean worktree can still contain local commits, so a divergent target branch produces an explicit error rather than discarding committed work.

## Validation

- validated regular-file, stdin-pipeline, and process-substitution runner invocation modes in an interactive PTY
- validated clean unrelated branch switching, existing event-branch fast-forwarding, and dirty checkout preservation with local Git remotes
- `bash -n tutorials/pyhpc/brev/cscs-launch-tutorial.bash`
- `shellcheck tutorials/pyhpc/brev/cscs-launch-tutorial.bash`
- `git diff --check`