### PR TITLE
Restart PyHPC web services after Jupyter shutdown

### DIFF
--- a/brev/entrypoint-jupyter.bash
+++ b/brev/entrypoint-jupyter.bash
@@ -4,8 +4,46 @@
 
 set -euo pipefail
 
+# Keep this wrapper alive so an unrequested Jupyter exit can restart the
+# sibling services before the container restart policy starts Jupyter again.
+# An operator stopping the container sends TERM/INT to this wrapper; that path
+# deliberately does not restart siblings so `compose down` can finish.
+TERMINATING=0
+JUPYTER_PID=""
+
+# shellcheck disable=SC2317 # Invoked indirectly by the signal traps below.
+terminate_jupyter() {
+    TERMINATING=1
+    if [ -n "${JUPYTER_PID}" ] && kill -0 "${JUPYTER_PID}" 2>/dev/null; then
+        kill -TERM "${JUPYTER_PID}"
+    fi
+}
+
+trap terminate_jupyter TERM INT
+
 if [ "$(id -u)" = "0" ] && [ "${ACH_TARGET_USER}" != "$(id -un)" ]; then
-    exec gosu "${ACH_TARGET_USER}" /accelerated-computing-hub/brev/entrypoint-jupyter-user.bash "$@"
+    gosu "${ACH_TARGET_USER}" /accelerated-computing-hub/brev/entrypoint-jupyter-user.bash "$@" &
 else
-    exec /accelerated-computing-hub/brev/entrypoint-jupyter-user.bash "$@"
+    /accelerated-computing-hub/brev/entrypoint-jupyter-user.bash "$@" &
 fi
+JUPYTER_PID=$!
+
+set +e
+wait "${JUPYTER_PID}"
+JUPYTER_STATUS=$?
+if [ "${TERMINATING}" -eq 1 ] && kill -0 "${JUPYTER_PID}" 2>/dev/null; then
+    wait "${JUPYTER_PID}"
+    JUPYTER_STATUS=$?
+fi
+set -e
+
+if [ "${TERMINATING}" -eq 0 ] && \
+   [ "${ACH_RESTART_COMPOSE_SERVICES:-}" = "1" ] && \
+   [ -S /var/run/docker.sock ]; then
+    echo "Jupyter exited with status ${JUPYTER_STATUS}; restarting sibling services."
+    if ! python3 /accelerated-computing-hub/brev/restart-compose-services.py; then
+        echo "Error: Failed to restart one or more sibling services." >&2
+    fi
+fi
+
+exit "${JUPYTER_STATUS}"

--- a/brev/restart-compose-services.py
+++ b/brev/restart-compose-services.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Restart the current container's persistent Docker Compose siblings."""
+
+import http.client
+import json
+import os
+import socket
+import sys
+import urllib.parse
+
+
+DOCKER_SOCKET = "/var/run/docker.sock"
+NON_PERSISTENT_SERVICES = {"base"}
+
+
+class UnixHTTPConnection(http.client.HTTPConnection):
+    """An HTTP connection transported over a Unix-domain socket."""
+
+    def __init__(self, socket_path):
+        super().__init__("localhost")
+        self.socket_path = socket_path
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.socket_path)
+
+
+def docker_request(method, path):
+    """Send one request to the Docker Engine API and return its body."""
+    connection = UnixHTTPConnection(DOCKER_SOCKET)
+    try:
+        connection.request(method, path)
+        response = connection.getresponse()
+        body = response.read()
+    finally:
+        connection.close()
+
+    if response.status >= 300:
+        detail = body.decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"Docker API {method} {path} returned {response.status}: {detail}"
+        )
+    return body
+
+
+def container_details(container_name):
+    """Return Docker metadata for a container name or ID."""
+    container_path = urllib.parse.quote(container_name, safe="")
+    return json.loads(docker_request("GET", f"/containers/{container_path}/json"))
+
+
+def main():
+    if not os.path.exists(DOCKER_SOCKET):
+        print(f"Docker socket not found at {DOCKER_SOCKET}")
+        return 0
+
+    current = container_details(socket.gethostname())
+    labels = current.get("Config", {}).get("Labels", {}) or {}
+    project = labels.get("com.docker.compose.project")
+    current_service = labels.get("com.docker.compose.service")
+    if not project or not current_service:
+        raise RuntimeError(
+            "Current container has no Docker Compose project/service labels"
+        )
+
+    filters = json.dumps({"label": [f"com.docker.compose.project={project}"]})
+    query = urllib.parse.urlencode({"all": "1", "filters": filters})
+    containers = json.loads(docker_request("GET", f"/containers/json?{query}"))
+
+    siblings = []
+    for container in containers:
+        sibling_labels = container.get("Labels", {}) or {}
+        service = sibling_labels.get("com.docker.compose.service")
+        one_off = sibling_labels.get("com.docker.compose.oneoff", "False")
+        if (
+            not service
+            or service == current_service
+            or service in NON_PERSISTENT_SERVICES
+        ):
+            continue
+        if one_off.lower() == "true":
+            continue
+        siblings.append((service, container["Id"]))
+
+    failed = False
+    for service, container_id in sorted(siblings):
+        try:
+            docker_request("POST", f"/containers/{container_id}/restart?t=10")
+        except (OSError, RuntimeError) as error:
+            print(
+                f"Error: Could not restart Compose service {project}/{service}: "
+                f"{error}",
+                file=sys.stderr,
+            )
+            failed = True
+        else:
+            print(f"Restarted Compose service {project}/{service}")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brev/test-docker-compose.bash
+++ b/brev/test-docker-compose.bash
@@ -184,11 +184,145 @@ services_started_successfully() {
     fi
 }
 
+test_jupyter_shutdown_restart() {
+    if is_podman; then
+        echo "🔄 Skipping Jupyter shutdown test for one-shot Podman base service"
+        return 0
+    fi
+
+    local service
+    local container_id
+    local started_at
+    local state
+    local deadline
+    local all_restarted
+    local restart_group
+    local service_list
+    local -a services=()
+    local -A started_before=()
+
+    # shellcheck disable=SC2016 # Expanded inside the container.
+    if ! restart_group=$(compose -f "${COMPOSE_FILE}" exec -T jupyter \
+        sh -c 'printf %s "${ACH_RESTART_COMPOSE_SERVICES:-}"'); then
+        echo "Error: could not read Jupyter restart configuration" >&2
+        return 1
+    fi
+    if [ "${restart_group}" != "1" ]; then
+        echo "🔄 Skipping Jupyter shutdown test for a tutorial without group restart"
+        return 0
+    fi
+
+    if ! service_list=$(compose -f "${COMPOSE_FILE}" config --services); then
+        echo "Error: could not read Compose services" >&2
+        return 1
+    fi
+    mapfile -t services < <(
+        grep -E '^(jupyter|nsight|nsys|ncu)$' <<<"${service_list}"
+    )
+    if [ "${#services[@]}" -eq 0 ]; then
+        echo "No persistent web services found; skipping Jupyter shutdown test"
+        return 0
+    fi
+
+    echo "🔄 Testing service-group restart after Jupyter shutdown..."
+    for service in "${services[@]}"; do
+        container_id=$(compose -f "${COMPOSE_FILE}" ps -q "${service}")
+        if [ -z "${container_id}" ]; then
+            echo "Error: no running container found for ${service}" >&2
+            return 1
+        fi
+        if ! started_at=$(
+            container inspect --format '{{.State.StartedAt}}' "${container_id}"
+        ); then
+            echo "Error: could not inspect ${service} container" >&2
+            return 1
+        fi
+        started_before["${service}"]=${started_at}
+    done
+
+    if ! compose -f "${COMPOSE_FILE}" exec -T jupyter python3 - <<'PY'
+import http.cookiejar
+import time
+import urllib.error
+import urllib.request
+
+cookies = http.cookiejar.CookieJar()
+opener = urllib.request.build_opener(
+    urllib.request.HTTPCookieProcessor(cookies)
+)
+deadline = time.monotonic() + 60
+while True:
+    try:
+        with opener.open("http://127.0.0.1:8888/lab", timeout=10):
+            break
+    except (OSError, urllib.error.URLError):
+        if time.monotonic() >= deadline:
+            raise
+        time.sleep(1)
+
+xsrf = next(cookie.value for cookie in cookies if cookie.name == "_xsrf")
+request = urllib.request.Request(
+    "http://127.0.0.1:8888/api/shutdown",
+    data=b"",
+    headers={"X-XSRFToken": xsrf},
+    method="POST",
+)
+with opener.open(request, timeout=10) as response:
+    if response.status >= 300:
+        raise RuntimeError(f"Jupyter shutdown returned HTTP {response.status}")
+PY
+    then
+        echo "Error: failed to request Jupyter shutdown" >&2
+        return 1
+    fi
+
+    deadline=$((SECONDS + 90))
+    while [ "${SECONDS}" -lt "${deadline}" ]; do
+        all_restarted=1
+        for service in "${services[@]}"; do
+            container_id=$(compose -f "${COMPOSE_FILE}" ps -q "${service}")
+            if [ -z "${container_id}" ]; then
+                all_restarted=0
+                continue
+            fi
+            state=$(container inspect --format '{{.State.Status}}' \
+                "${container_id}" 2>/dev/null || true)
+            started_at=$(container inspect --format '{{.State.StartedAt}}' \
+                "${container_id}" 2>/dev/null || true)
+            if [ "${state}" != "running" ] || \
+               [ "${started_at}" = "${started_before[${service}]}" ]; then
+                all_restarted=0
+            fi
+        done
+        if [ "${all_restarted}" -eq 1 ]; then
+            echo -e "${GREEN}✅ Jupyter shutdown restarted the full service group${NC}"
+            echo ""
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "Error: service group did not restart within 90 seconds" >&2
+    for service in "${services[@]}"; do
+        container_id=$(compose -f "${COMPOSE_FILE}" ps -aq "${service}" | head -n 1)
+        if [ -n "${container_id}" ]; then
+            state=$(container inspect --format '{{.State.Status}}' "${container_id}")
+            started_at=$(container inspect --format '{{.State.StartedAt}}' "${container_id}")
+            printf '  %s: state=%s started=%s previous=%s\n' \
+                "${service}" "${state}" "${started_at}" "${started_before[${service}]}" >&2
+        fi
+    done
+    compose -f "${COMPOSE_FILE}" logs --tail=100 >&2 || true
+    return 1
+}
+
 restart_services() {
     if is_podman; then
         echo "🔄 Skipping service restart test for one-shot Podman base service"
         return 0
     fi
+
+    test_jupyter_shutdown_restart || return 1
 
     if ! compose -f "${COMPOSE_FILE}" restart; then
         echo ""

--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -357,6 +357,7 @@ fi
 RUN_STATE="${ACH_STATE}/${SLURM_JOB_ID}"
 mkdir -p "${RUN_STATE}" "${ACH_RUNTIME_REPO}/logs"
 chmod 700 "${ACH_STATE}" "${RUN_STATE}"
+SERVICE_EVENTS="${RUN_STATE}/service-events"
 
 SOURCE_COMPOSE="${RUN_STATE}/docker-compose.yml"
 PODMAN_COMPOSE="${RUN_STATE}/docker-compose.podman.yml"
@@ -424,17 +425,23 @@ clean_store() {
 }
 
 pids=()
-cleanup() {
-    local status=$?
-    trap - EXIT INT TERM
-    set +e
+stop_services() {
     if [ "${#pids[@]}" -gt 0 ]; then
-        kill "${pids[@]}" 2>/dev/null
-        wait "${pids[@]}" 2>/dev/null
+        kill "${pids[@]}" 2>/dev/null || true
     fi
     for store in main nsys ncu; do
         clean_store "${store}"
     done
+    for pid in "${pids[@]}"; do
+        wait "${pid}" 2>/dev/null || true
+    done
+    pids=()
+}
+
+cleanup() {
+    local status=$?
+    trap - EXIT INT TERM
+    stop_services
     podman unshare rm -rf "${JOB_ROOT}" >/dev/null 2>&1 || true
     exit "${status}"
 }
@@ -473,26 +480,44 @@ start_service() {
         CONTAINERS_STORAGE_CONF=$(store_conf "${store}")
         export XDG_RUNTIME_DIR
         XDG_RUNTIME_DIR="$(store_root "${store}")/runtime"
-        exec "${COMPOSE}" --podman-run-args=--cgroups=disabled \
+        service_pid=""
+        terminating=0
+        terminate_service() {
+            terminating=1
+            if [ -n "${service_pid}" ] && kill -0 "${service_pid}" 2>/dev/null; then
+                kill -TERM "${service_pid}" 2>/dev/null || true
+            fi
+        }
+        trap terminate_service TERM INT
+
+        "${COMPOSE}" --podman-run-args=--cgroups=disabled \
             -f "${PODMAN_COMPOSE}" \
             run --rm --no-deps -T \
             -e "TURN_USERNAME=${TURN_USERNAME}" -e "TURN_PASSWORD=${TURN_PASSWORD}" \
-            "${service}"
-    ) >"${log}" 2>&1 &
+            "${service}" &
+        service_pid=$!
+        service_status=0
+        wait "${service_pid}" || service_status=$?
+        if [ "${terminating}" -eq 1 ] && kill -0 "${service_pid}" 2>/dev/null; then
+            wait "${service_pid}" || service_status=$?
+        fi
+        printf '%s %s\n' "${service}" "${service_status}" >>"${SERVICE_EVENTS}"
+        exit "${service_status}"
+    ) >>"${log}" 2>&1 &
     local pid=$!
     chmod 600 "${log}"
     pids+=("${pid}")
 
     local deadline=$((SECONDS + 300))
     while [ "${SECONDS}" -lt "${deadline}" ]; do
+        if [ -s "${SERVICE_EVENTS}" ]; then
+            echo "Error: a web service exited while waiting for ${service}; see ${RUN_STATE}/*.log" >&2
+            return 1
+        fi
         if curl --fail --silent \
             --connect-timeout 1 --max-time 2 "${url}" >/dev/null 2>&1; then
             echo "${service} is ready"
             return 0
-        fi
-        if ! kill -0 "${pid}" 2>/dev/null; then
-            echo "Error: ${service} exited; see ${log}" >&2
-            return 1
         fi
         sleep 1
     done
@@ -501,19 +526,49 @@ start_service() {
     return 1
 }
 
-start_service jupyter main http://127.0.0.1:8888/api/status
-start_service nsys nsys http://127.0.0.1:8080/health
-start_service ncu ncu http://127.0.0.1:8081/health
+generation=0
+ready_announced=0
+while true; do
+    generation=$((generation + 1))
+    pids=()
+    : >"${SERVICE_EVENTS}"
+    chmod 600 "${SERVICE_EVENTS}"
+    for service in jupyter nsys ncu; do
+        printf '\n=== Starting service generation %s ===\n' "${generation}" \
+            >>"${RUN_STATE}/${service}.log"
+    done
 
-echo "READY node=$(hostname -s)"
-echo "Logs: ${RUN_STATE}/{jupyter,nsys,ncu}.log"
+    if ! start_service jupyter main http://127.0.0.1:8888/api/status || \
+       ! start_service nsys nsys http://127.0.0.1:8080/health || \
+       ! start_service ncu ncu http://127.0.0.1:8081/health; then
+        echo "Web service generation ${generation} failed during startup; restarting all services." >&2
+        stop_services
+        sleep 5
+        continue
+    fi
+    if [ -s "${SERVICE_EVENTS}" ]; then
+        echo "A web service exited immediately after startup; restarting all services." >&2
+        stop_services
+        sleep 5
+        continue
+    fi
 
-set +e
-wait -n "${pids[@]}"
-status=$?
-set -e
-echo "A web service exited; stopping the deployment." >&2
-exit "${status}"
+    if [ "${ready_announced}" -eq 0 ]; then
+        echo "READY node=$(hostname -s)"
+        echo "Logs: ${RUN_STATE}/{jupyter,nsys,ncu}.log"
+        ready_announced=1
+    else
+        echo "Web service generation ${generation} is ready."
+    fi
+
+    while [ ! -s "${SERVICE_EVENTS}" ]; do
+        sleep 1
+    done
+    read -r exited_service exited_status <"${SERVICE_EVENTS}"
+    echo "${exited_service} exited with status ${exited_status}; restarting JupyterLab and both Nsight Streamers." >&2
+    stop_services
+    sleep 1
+done
 }
 
 if [ "${1:-}" = --batch ]; then

--- a/tutorials/pyhpc/brev/docker-compose.yml
+++ b/tutorials/pyhpc/brev/docker-compose.yml
@@ -25,6 +25,7 @@ x-config:
     ACH_TUTORIAL: *tutorial-name
     ACH_RUN_TESTS: ${ACH_RUN_TESTS:-}
     ACH_TEST_ARGS: ${ACH_TEST_ARGS:-}
+    ACH_RESTART_COMPOSE_SERVICES: "1"
     ACH_USER: ${ACH_USER:-ach}
     ACH_UID: ${ACH_UID:-1000}
     ACH_GID: ${ACH_GID:-1000}


### PR DESCRIPTION
## Summary

- opt only the PyHPC tutorial into Compose service-group restart on the event branch
- keep the shared Jupyter wrapper inert for every other event-branch tutorial
- restart the complete PyHPC Jupyter/NSYS/NCU generation inside the existing CSCS allocation when a web service exits
- add lifecycle regression coverage for opted-in tutorials

The corresponding all-tutorial main-branch implementation is in #210.

## Root cause

Compose restart policies apply per container, so Brev and local Docker restarted only Jupyter. CSCS uses separate `podman-compose run --rm` processes, where restart policies are disabled, and its launcher previously ended the deployment after the first service exit.

## Validation

- disposable Docker Compose integration: PyHPC opt-in restarted Jupyter, NSYS, and NCU; an operator stop did not cascade
- live Daint job 4275016 on nid005311: shutdown returned HTTP 200, all three logs advanced to generation 2, the allocation remained running, and all three restarted endpoints returned HTTP 200; test allocation was canceled afterward
- only `tutorials/pyhpc/brev/docker-compose.yml` enables `ACH_RESTART_COMPOSE_SERVICES` on the event branch
- Bash syntax, ShellCheck, Python compilation, all Compose configs, repository hooks, and signed commit verification
