### PR TITLE
Rename PyHPC eight-hour tutorial

### DIFF
--- a/tutorials/pyhpc/README.md
+++ b/tutorials/pyhpc/README.md
@@ -13,7 +13,7 @@ Brev Launchables of this tutorial should use:
 
 ## Syllabi
 
-- [PyHPC - CuPy, mpi4py, JAX, CppInterOp, & CUDA Kernels - 8 Hours](./notebooks/syllabi/pyhpc__cupy_mpi4py_jax_cppinterop_kernels__8_hours.ipynb)
+- [PyHPC Tutorial - CuPy, Kernels, MPI, JAX, OMP, Interop - 8 Hours](./notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__8_hours.ipynb)
 
 ## Notebooks
 

--- a/tutorials/pyhpc/brev/docker-compose.yml
+++ b/tutorials/pyhpc/brev/docker-compose.yml
@@ -6,7 +6,7 @@ x-config:
   working-dir: &working-dir /accelerated-computing-hub/tutorials/pyhpc/notebooks
   large: &large true
   architectures: [amd64, arm64]
-  default-jupyter-url: &default-jupyter-url "/lab/tree/accelerated-computing-hub/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_mpi4py_jax_cppinterop_kernels__8_hours.ipynb?file-browser-path=/accelerated-computing-hub/tutorials/pyhpc/notebooks"
+  default-jupyter-url: &default-jupyter-url "/lab/tree/accelerated-computing-hub/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__8_hours.ipynb?file-browser-path=/accelerated-computing-hub/tutorials/pyhpc/notebooks"
   gpu-config: &gpu-config
     privileged: true
     ulimits:

--- a/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__8_hours.ipynb
+++ b/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__8_hours.ipynb
@@ -5,7 +5,7 @@
    "id": "c9fb56fd",
    "metadata": {},
    "source": [
-    "## PyHPC Tutorial - CuPy, mpi4py, JAX, CppInterOp, & CUDA Kernels - 8 Hours\n",
+    "## PyHPC Tutorial - CuPy, Kernels, MPI, JAX, OMP, Interop - 8 Hours\n",
     "\n",
     "### Notebooks\n",
     "\n",
@@ -30,7 +30,7 @@
     "\n",
     "| Docker Compose | Brev Instance | Brev Provider |\n",
     "|----------------|---------------|---------------|\n",
-    "| [Link](https://github.com/NVIDIA/accelerated-computing-hub/blob/generated/main/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_mpi4py_jax_cppinterop_kernels__8_hours__docker_compose.yml) | 4xL4, 2xL4, 2xL40S, or 1x L40S | Crusoe or any other with Flexible Ports |\n",
+    "| [Link](https://github.com/NVIDIA/accelerated-computing-hub/blob/generated/main/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__8_hours__docker_compose.yml) | 4xL4, 2xL4, 2xL40S, or 1x L40S | Crusoe or any other with Flexible Ports |\n",
     "\n",
     "### Introduction\n",
     "\n",


### PR DESCRIPTION
## Summary

- rename the syllabus to `pyhpc__cupy_kernels_mpi_jax_omp_interop__8_hours.ipynb`
- change its title to **PyHPC Tutorial - CuPy, Kernels, MPI, JAX, OMP, Interop - 8 Hours**
- update the PyHPC README, default Jupyter route, and generated Docker Compose link

## Validation

- focused pre-commit hooks
- notebook JSON and canonical-format validation
- verified all local syllabus links resolve
- generated the PyHPC base and syllabus Docker Compose files and confirmed the renamed output/path
- `git diff --check`