### PR TITLE
Rename PyHPC tutorial duration to 2 Days

### DIFF
--- a/tutorials/pyhpc/README.md
+++ b/tutorials/pyhpc/README.md
@@ -13,7 +13,7 @@ Brev Launchables of this tutorial should use:
 
 ## Syllabi
 
-- [PyHPC Tutorial - CuPy, Kernels, MPI, JAX, OMP, Interop - 8 Hours](./notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__8_hours.ipynb)
+- [PyHPC Tutorial - CuPy, Kernels, MPI, JAX, OMP, Interop - 2 Days](./notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__2_days.ipynb)
 
 ## Notebooks
 

--- a/tutorials/pyhpc/brev/docker-compose.yml
+++ b/tutorials/pyhpc/brev/docker-compose.yml
@@ -6,7 +6,7 @@ x-config:
   working-dir: &working-dir /accelerated-computing-hub/tutorials/pyhpc/notebooks
   large: &large true
   architectures: [amd64, arm64]
-  default-jupyter-url: &default-jupyter-url "/lab/tree/accelerated-computing-hub/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__8_hours.ipynb?file-browser-path=/accelerated-computing-hub/tutorials/pyhpc/notebooks"
+  default-jupyter-url: &default-jupyter-url "/lab/tree/accelerated-computing-hub/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__2_days.ipynb?file-browser-path=/accelerated-computing-hub/tutorials/pyhpc/notebooks"
   gpu-config: &gpu-config
     privileged: true
     ulimits:

--- a/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__2_days.ipynb
+++ b/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__2_days.ipynb
@@ -5,7 +5,7 @@
    "id": "c9fb56fd",
    "metadata": {},
    "source": [
-    "## PyHPC Tutorial - CuPy, Kernels, MPI, JAX, OMP, Interop - 8 Hours\n",
+    "## PyHPC Tutorial - CuPy, Kernels, MPI, JAX, OMP, Interop - 2 Days\n",
     "\n",
     "### Notebooks\n",
     "\n",
@@ -30,7 +30,7 @@
     "\n",
     "| Docker Compose | Brev Instance | Brev Provider |\n",
     "|----------------|---------------|---------------|\n",
-    "| [Link](https://github.com/NVIDIA/accelerated-computing-hub/blob/generated/main/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__8_hours__docker_compose.yml) | 4xL4, 2xL4, 2xL40S, or 1x L40S | Crusoe or any other with Flexible Ports |\n",
+    "| [Link](https://github.com/NVIDIA/accelerated-computing-hub/blob/generated/main/tutorials/pyhpc/notebooks/syllabi/pyhpc__cupy_kernels_mpi_jax_omp_interop__2_days__docker_compose.yml) | 4xL4, 2xL4, 2xL40S, or 1x L40S | Crusoe or any other with Flexible Ports |\n",
     "\n",
     "### Introduction\n",
     "\n",


### PR DESCRIPTION
## Summary

- change the PyHPC tutorial title from `8 Hours` to `2 Days`
- rename the syllabus from `__8_hours.ipynb` to `__2_days.ipynb`
- update the README, default Jupyter URL, and generated syllabus Compose link

## Validation

- focused pre-commit checks
- generated the PyHPC base and syllabus Compose files and verified the `__2_days` output
- confirmed no `8 Hours` or `8_hours` references remain under `tutorials/pyhpc`
- `git diff --check`