### PR TITLE
Fix PyHPC asynchrony notebook profiling flow

### DIFF
--- a/brev/test-notebook-format.py
+++ b/brev/test-notebook-format.py
@@ -84,6 +84,19 @@ NSIGHT_SYSTEMS_NOTEBOOKS = {
     "tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb",
 }
 
+NSIGHT_COMPUTE_KERNELSPEC = {
+    "display_name": "Python 3 (Nsight Compute)",
+    "language": "python",
+    "name": "nsightful-ncu",
+}
+
+NSIGHT_COMPUTE_NOTEBOOKS = {
+    "tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb",
+    "tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb",
+    "tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb",
+    "tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb",
+}
+
 STANDARD_NBFORMAT = 4
 STANDARD_NBFORMAT_MINOR = 5
 
@@ -113,6 +126,8 @@ def expected_metadata_for_notebook(notebook_path: Path) -> dict:
 
     if relative_path.as_posix() in NSIGHT_SYSTEMS_NOTEBOOKS:
         expected["kernelspec"] = NSIGHT_SYSTEMS_KERNELSPEC
+    elif relative_path.as_posix() in NSIGHT_COMPUTE_NOTEBOOKS:
+        expected["kernelspec"] = NSIGHT_COMPUTE_KERNELSPEC
     return expected
 
 

--- a/brev/test-notebook-format.py
+++ b/brev/test-notebook-format.py
@@ -79,23 +79,17 @@ NSIGHT_SYSTEMS_KERNELSPEC = {
     "name": "nsightful-nsys",
 }
 
-NSIGHT_SYSTEMS_NOTEBOOKS = {
-    "tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb",
-    "tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb",
-}
-
 NSIGHT_COMPUTE_KERNELSPEC = {
     "display_name": "Python 3 (Nsight Compute)",
     "language": "python",
     "name": "nsightful-ncu",
 }
 
-NSIGHT_COMPUTE_NOTEBOOKS = {
-    "tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb",
-    "tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb",
-    "tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb",
-    "tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb",
-}
+ALLOWED_KERNELSPECS = (
+    STANDARD_METADATA["kernelspec"],
+    NSIGHT_SYSTEMS_KERNELSPEC,
+    NSIGHT_COMPUTE_KERNELSPEC,
+)
 
 STANDARD_NBFORMAT = 4
 STANDARD_NBFORMAT_MINOR = 5
@@ -118,16 +112,14 @@ def is_solution_notebook(notebook_path: Path) -> bool:
 def expected_metadata_for_notebook(notebook_path: Path) -> dict:
     expected = dict(STANDARD_METADATA)
     try:
-        relative_path = notebook_path.resolve().relative_to(
-            Path(__file__).resolve().parent.parent
-        )
-    except ValueError:
+        with open(notebook_path, "r", encoding="utf-8") as f:
+            metadata = json.load(f).get("metadata", {})
+    except (OSError, json.JSONDecodeError):
         return expected
 
-    if relative_path.as_posix() in NSIGHT_SYSTEMS_NOTEBOOKS:
-        expected["kernelspec"] = NSIGHT_SYSTEMS_KERNELSPEC
-    elif relative_path.as_posix() in NSIGHT_COMPUTE_NOTEBOOKS:
-        expected["kernelspec"] = NSIGHT_COMPUTE_KERNELSPEC
+    kernelspec = metadata.get("kernelspec")
+    if kernelspec in ALLOWED_KERNELSPECS:
+        expected["kernelspec"] = kernelspec
     return expected
 
 

--- a/brev/test-notebook-format.py
+++ b/brev/test-notebook-format.py
@@ -73,6 +73,17 @@ STANDARD_METADATA = {
     },
 }
 
+NSIGHT_SYSTEMS_KERNELSPEC = {
+    "display_name": "Python 3 (Nsight Systems)",
+    "language": "python",
+    "name": "nsightful-nsys",
+}
+
+NSIGHT_SYSTEMS_NOTEBOOKS = {
+    "tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb",
+    "tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb",
+}
+
 STANDARD_NBFORMAT = 4
 STANDARD_NBFORMAT_MINOR = 5
 
@@ -89,6 +100,20 @@ NC = "\033[0m"  # No Color
 
 def is_solution_notebook(notebook_path: Path) -> bool:
     return "SOLUTION" in notebook_path.name
+
+
+def expected_metadata_for_notebook(notebook_path: Path) -> dict:
+    expected = dict(STANDARD_METADATA)
+    try:
+        relative_path = notebook_path.resolve().relative_to(
+            Path(__file__).resolve().parent.parent
+        )
+    except ValueError:
+        return expected
+
+    if relative_path.as_posix() in NSIGHT_SYSTEMS_NOTEBOOKS:
+        expected["kernelspec"] = NSIGHT_SYSTEMS_KERNELSPEC
+    return expected
 
 
 def diff_metadata(actual: dict, expected: dict, path: str = "") -> list[str]:
@@ -147,7 +172,7 @@ def canonicalize_notebook(notebook_path: Path) -> tuple[str, list[str]]:
 
     # -- Detect original metadata problems before nbformat.read() -----------
     actual_metadata = raw.get("metadata", {})
-    expected_metadata = dict(STANDARD_METADATA)
+    expected_metadata = expected_metadata_for_notebook(notebook_path)
     metadata_diffs = diff_metadata(actual_metadata, expected_metadata, "metadata")
     if metadata_diffs:
         problems.extend(metadata_diffs)

--- a/tutorials/pyhpc/brev/requirements.txt
+++ b/tutorials/pyhpc/brev/requirements.txt
@@ -25,7 +25,7 @@ cuda-cccl[test-cu13] == 0.4.5
 
 # NVIDIA developer tools (notebooks 03-05: Nsight Systems / Nsight Compute profiling)
 nvtx == 0.2.14
-nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059
+nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5
 
 # Distributed computing (notebook 06: mpi4py)
 mpi4py == 4.1.1

--- a/tutorials/pyhpc/brev/requirements.txt
+++ b/tutorials/pyhpc/brev/requirements.txt
@@ -25,7 +25,7 @@ cuda-cccl[test-cu13] == 0.4.5
 
 # NVIDIA developer tools (notebooks 03-05: Nsight Systems / Nsight Compute profiling)
 nvtx == 0.2.14
-nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c
+nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2
 
 # Distributed computing (notebook 06: mpi4py)
 mpi4py == 4.1.1

--- a/tutorials/pyhpc/brev/requirements.txt
+++ b/tutorials/pyhpc/brev/requirements.txt
@@ -25,7 +25,7 @@ cuda-cccl[test-cu13] == 0.4.5
 
 # NVIDIA developer tools (notebooks 03-05: Nsight Systems / Nsight Compute profiling)
 nvtx == 0.2.14
-nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d
+nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059
 
 # Distributed computing (notebook 06: mpi4py)
 mpi4py == 4.1.1

--- a/tutorials/pyhpc/brev/requirements.txt
+++ b/tutorials/pyhpc/brev/requirements.txt
@@ -25,7 +25,7 @@ cuda-cccl[test-cu13] == 0.4.5
 
 # NVIDIA developer tools (notebooks 03-05: Nsight Systems / Nsight Compute profiling)
 nvtx == 0.2.14
-nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@196bc4e292571973969179d7d48e687a2720bb2f
+nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42
 
 # Distributed computing (notebook 06: mpi4py)
 mpi4py == 4.1.1

--- a/tutorials/pyhpc/brev/requirements.txt
+++ b/tutorials/pyhpc/brev/requirements.txt
@@ -25,7 +25,7 @@ cuda-cccl[test-cu13] == 0.4.5
 
 # NVIDIA developer tools (notebooks 03-05: Nsight Systems / Nsight Compute profiling)
 nvtx == 0.2.14
-nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5
+nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@fa9ee4d81441ac62379c5306f2f2d8b0894d06ec
 
 # Distributed computing (notebook 06: mpi4py)
 mpi4py == 4.1.1

--- a/tutorials/pyhpc/brev/requirements.txt
+++ b/tutorials/pyhpc/brev/requirements.txt
@@ -25,7 +25,7 @@ cuda-cccl[test-cu13] == 0.4.5
 
 # NVIDIA developer tools (notebooks 03-05: Nsight Systems / Nsight Compute profiling)
 nvtx == 0.2.14
-nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f
+nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d
 
 # Distributed computing (notebook 06: mpi4py)
 mpi4py == 4.1.1

--- a/tutorials/pyhpc/brev/requirements.txt
+++ b/tutorials/pyhpc/brev/requirements.txt
@@ -25,7 +25,7 @@ cuda-cccl[test-cu13] == 0.4.5
 
 # NVIDIA developer tools (notebooks 03-05: Nsight Systems / Nsight Compute profiling)
 nvtx == 0.2.14
-nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42
+nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b
 
 # Distributed computing (notebook 06: mpi4py)
 mpi4py == 4.1.1

--- a/tutorials/pyhpc/brev/requirements.txt
+++ b/tutorials/pyhpc/brev/requirements.txt
@@ -25,7 +25,7 @@ cuda-cccl[test-cu13] == 0.4.5
 
 # NVIDIA developer tools (notebooks 03-05: Nsight Systems / Nsight Compute profiling)
 nvtx == 0.2.14
-nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b
+nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c
 
 # Distributed computing (notebook 06: mpi4py)
 mpi4py == 4.1.1

--- a/tutorials/pyhpc/brev/requirements.txt
+++ b/tutorials/pyhpc/brev/requirements.txt
@@ -25,7 +25,7 @@ cuda-cccl[test-cu13] == 0.4.5
 
 # NVIDIA developer tools (notebooks 03-05: Nsight Systems / Nsight Compute profiling)
 nvtx == 0.2.14
-nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2
+nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f
 
 # Distributed computing (notebook 06: mpi4py)
 mpi4py == 4.1.1

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@196bc4e292571973969179d7d48e687a2720bb2f\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@fa9ee4d81441ac62379c5306f2f2d8b0894d06ec\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -54,11 +54,10 @@
     "import cupy as cp\n",
     "import cupyx as cpx\n",
     "import nvtx\n",
-    "import time\n",
     "from dataclasses import dataclass\n",
     "from jupyter_dark_detect import is_dark\n",
     "import matplotlib.pyplot as plt\n",
-    "plt.style.use('dark_background' if is_dark() else 'default')\n"
+    "plt.style.use('dark_background' if is_dark() else 'default')"
    ]
   },
   {
@@ -90,10 +89,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19924fe0",
-   "metadata": {
-    "id": "sEicxhLO_9G9"
-   },
+   "id": "7dd38317",
+   "metadata": {},
    "outputs": [],
    "source": [
     "@dataclass\n",
@@ -103,16 +100,42 @@
     "  max_steps: int = 400\n",
     "  check_frequency: int = 25\n",
     "  progress: bool = True\n",
-    "  residual_threshold: float = 1e-10\n",
-    "\n",
+    "  residual_threshold: float = 1e-10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81b3f4c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def generate_device(cfg=PowerIterationConfig()):\n",
     "  cp.random.seed(42)\n",
     "  weak_lam = cp.random.random(cfg.dim - 1) * (1.0 - cfg.dominance)\n",
     "  lam = cp.random.permutation(cp.concatenate((cp.asarray([1.0]), weak_lam)))\n",
     "  P = cp.random.random((cfg.dim, cfg.dim))\n",
     "  D = cp.diag(cp.random.permutation(lam))\n",
-    "  return (P @ D) @ cp.linalg.inv(P)\n",
-    "\n",
+    "  return (P @ D) @ cp.linalg.inv(P)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f083598a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A_device = generate_device()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8cdd65d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def estimate_device_baseline(A, cfg=PowerIterationConfig()) -> np.ndarray:\n",
     "  A_gpu = cp.asarray(A)\n",
     "  x = cp.ones(A_gpu.shape[0], dtype=np.float64)\n",
@@ -136,11 +159,10 @@
     "\n",
     "  return cp.asnumpy((x.T @ (A_gpu @ x)) / (x.T @ x))\n",
     "\n",
-    "A_device = generate_device()\n",
     "estimate_device_baseline(\n",
     "  A_device,\n",
     "  cfg=PowerIterationConfig(max_steps=1, check_frequency=1, progress=False),\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -152,7 +174,7 @@
    "source": [
     "### 4. Profiling the Baseline\n",
     "\n",
-    "Select the **Python 3 (Nsight Systems)** kernel, then profile the baseline in place. The `%%nsys` magic collects only this cell and displays the resulting timeline without restarting the kernel."
+    "This notebook uses the **Python 3 (Nsight Systems)** kernel so we can profile the baseline in place. The `%%nsys` magic collects only this cell and displays the resulting timeline without restarting the kernel."
    ]
   },
   {
@@ -166,7 +188,7 @@
    "source": [
     "%%nsys -o power_iteration__baseline.nsys-rep\n",
     "lam_est_baseline = estimate_device_baseline(A_device)\n",
-    "np.testing.assert_allclose(lam_est_baseline, 1, atol=1e-4)\n"
+    "np.testing.assert_allclose(lam_est_baseline, 1, atol=1e-4)"
    ]
   },
   {
@@ -202,35 +224,16 @@
    "source": [
     "### 5. Better Visibility with NVTX\n",
     "\n",
-    "Nsight Systems shows us a lot of information - sometimes it's too much and not all relevant.\n",
-    "\n",
-    "There's two ways that we can filter and annotate what we see in Nsight systems.\n",
-    "\n",
-    "The first is to limit when we start and stop profiling in the program. In Python, we can do this with `cupyx.profiler.profile()`, which give us a Python context manager. Any CUDA code used during scope will be included in the profile.\n",
-    "\n",
-    "```\n",
-    "not_in_the_profile()\n",
-    "with cpx.profiler.profile():\n",
-    "  in_the_profile()\n",
-    "not_in_the_profile()\n",
-    "```\n",
-    "\n",
-    "For this to work, we have to pass `--capture-range=cudaProfilerApi --capture-range-end=stop` as flags to `nsys`.\n",
-    "\n",
-    "We can also annotate specific regions of our code, which will show up in the profiler. We can even add categories, domains, and colors to these regions, and they can be nested. To add these annotations, we use `nvtx.annotate()`, another Python context manager, this time from a library called NVTX.\n",
+    "Nsight Systems shows us a lot of information—sometimes too much, and not all of it is relevant. We can annotate specific regions of our code so they stand out in the timeline. These regions can have categories, domains, and colors, and they can be nested. To add them, use the `nvtx.annotate()` context manager:\n",
     "\n",
     "```\n",
     "with nvtx.annotate(\"Loop\"):\n",
     "  for i in range(20):\n",
-    "     with nvtx.annotate(f\"Step {i}\"):\n",
-    "       pass\n",
+    "    with nvtx.annotate(f\"Step {i}\"):\n",
+    "      pass\n",
     "```\n",
     "\n",
-    "**TODO:** Go back to the earlier cells and improve the profile results by adding:\n",
-    "\n",
-    "- `nvtx.annotate()` regions. Remember, you can nest them.\n",
-    "- A `cpx.profiler.profile()` around the `start =`/`stop =` lines that run the solver.\n",
-    "- `--capture-range=cudaProfilerApi --capture-range-end=stop` to the `nsys` flags.\n",
+    "**TODO:** Go back to the baseline estimator and add nested `nvtx.annotate()` regions around its setup, loop, compute, copy, and I/O phases.\n",
     "\n",
     "Then, capture another profile and see if you can identify how we can improve the code. Specifically, think about how we could add more asynchrony."
    ]
@@ -263,7 +266,7 @@
    "outputs": [],
    "source": [
     "def estimate_device_async(A, cfg=PowerIterationConfig()) -> np.ndarray:\n",
-    "  raise NotImplementedError(\"TODO: Adapt the baseline estimator to overlap checkpoint copies and I/O with GPU compute!\")\n"
+    "  raise NotImplementedError(\"TODO: Adapt the baseline estimator to overlap checkpoint copies and I/O with GPU compute!\")"
    ]
   },
   {
@@ -284,7 +287,7 @@
    "outputs": [],
    "source": [
     "lam_est_async = estimate_device_async(A_device)\n",
-    "np.testing.assert_allclose(lam_est_async, 1, atol=1e-4)\n"
+    "np.testing.assert_allclose(lam_est_async, 1, atol=1e-4)"
    ]
   },
   {
@@ -308,21 +311,18 @@
    },
    "outputs": [],
    "source": [
-    "def time_estimator(estimator, cfg):\n",
-    "  cp.cuda.get_current_stream().synchronize()\n",
-    "  start = time.perf_counter()\n",
-    "  result = estimator(A_device, cfg=cfg)\n",
-    "  cp.cuda.get_current_stream().synchronize()\n",
-    "  return result, (time.perf_counter() - start) * 1000\n",
-    "\n",
     "quiet_cfg = PowerIterationConfig(progress=False)\n",
-    "_, power_iteration_baseline_duration = time_estimator(estimate_device_baseline, quiet_cfg)\n",
-    "_, power_iteration_async_duration = time_estimator(estimate_device_async, quiet_cfg)\n",
+    "power_iteration_baseline_duration = cpx.profiler.benchmark(\n",
+    "  estimate_device_baseline, (A_device, quiet_cfg), n_repeat=5, n_warmup=1\n",
+    ").cpu_times.mean() * 1000\n",
+    "power_iteration_async_duration = cpx.profiler.benchmark(\n",
+    "  estimate_device_async, (A_device, quiet_cfg), n_repeat=5, n_warmup=1\n",
+    ").cpu_times.mean() * 1000\n",
     "speedup = power_iteration_baseline_duration / power_iteration_async_duration\n",
     "\n",
     "print(f\"power_iteration_baseline: {power_iteration_baseline_duration:.3f} ms\")\n",
     "print(f\"power_iteration_async:    {power_iteration_async_duration:.3f} ms\")\n",
-    "print(f\"power_iteration_async speedup over power_iteration_baseline: {speedup:.2f}\")\n"
+    "print(f\"power_iteration_async speedup over power_iteration_baseline: {speedup:.2f}\")"
    ]
   },
   {
@@ -346,7 +346,7 @@
    "source": [
     "%%nsys -o power_iteration__async.nsys-rep\n",
     "lam_est_async = estimate_device_async(A_device)\n",
-    "np.testing.assert_allclose(lam_est_async, 1, atol=1e-4)\n"
+    "np.testing.assert_allclose(lam_est_async, 1, atol=1e-4)"
    ]
   },
   {
@@ -398,7 +398,7 @@
     "    timing = cpx.profiler.benchmark(\n",
     "        estimate_device_async, (A_device, cfg), n_repeat=5, n_warmup=1\n",
     "    )\n",
-    "    async_durations.append(timing.cpu_times.mean() * 1000)\n"
+    "    async_durations.append(timing.cpu_times.mean() * 1000)"
    ]
   },
   {
@@ -430,7 +430,7 @@
     "%%nsys -o power_iteration__async__optimal.nsys-rep\n",
     "optimal_cfg = PowerIterationConfig(check_frequency=optimal_check_frequency)\n",
     "lam_est_optimal = estimate_device_async(A_device, cfg=optimal_cfg)\n",
-    "np.testing.assert_allclose(lam_est_optimal, 1, atol=1e-4)\n"
+    "np.testing.assert_allclose(lam_est_optimal, 1, atol=1e-4)"
    ]
   }
  ],
@@ -442,9 +442,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Nsight Systems)",
    "language": "python",
-   "name": "python3"
+   "name": "nsightful-nsys"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -380,7 +380,7 @@
     "\n",
     "Our asynchronous implementation overlaps checkpoint I/O on the CPU with power-iteration steps on the GPU. `check_frequency` controls how many GPU steps run between residual checks and checkpoints. A smaller value produces output more frequently, but may not provide enough GPU work to hide the I/O. A larger value provides more GPU work to overlap with the I/O, but delays output and convergence checks.\n",
     "\n",
-    "**TODO:** Sweep check frequencies from 20 through 30 in increments of 1 and determine the output frequency with the lowest execution time. Create a `PowerIterationConfig` for each value, time `estimate_device_async`, and plot the results."
+    "**TODO:** Sweep check frequencies from 20 through 35 in increments of 1 and determine the output frequency with the lowest execution time. Use `cupyx.profiler.benchmark` with progress disabled, then plot the results."
    ]
   },
   {
@@ -390,13 +390,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "check_frequencies = list(range(20, 31))\n",
+    "check_frequencies = list(range(20, 36))\n",
     "async_durations = []\n",
     "\n",
     "for check_frequency in check_frequencies:\n",
     "    cfg = PowerIterationConfig(check_frequency=check_frequency, progress=False)\n",
-    "    # TODO: Time estimate_device_async with this configuration and append the duration.\n",
-    "    TODO()\n"
+    "    timing = cpx.profiler.benchmark(\n",
+    "        estimate_device_async, (A_device, cfg), n_repeat=5, n_warmup=1\n",
+    "    )\n",
+    "    async_durations.append(timing.cpu_times.mean() * 1000)\n"
    ]
   },
   {

--- a/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
+++ b/tutorials/pyhpc/notebooks/03__power_iteration__cupy__asynchrony.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -51,7 +51,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -51,7 +51,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@196bc4e292571973969179d7d48e687a2720bb2f\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -51,7 +51,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -51,7 +51,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -51,7 +51,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -51,7 +51,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@fa9ee4d81441ac62379c5306f2f2d8b0894d06ec\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -342,9 +342,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Nsight Compute)",
    "language": "python",
-   "name": "python3"
+   "name": "nsightful-ncu"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -51,7 +51,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -51,7 +51,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/04__copy__kernel_authoring.ipynb
@@ -51,7 +51,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -395,9 +395,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Nsight Compute)",
    "language": "python",
-   "name": "python3"
+   "name": "nsightful-ncu"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@fa9ee4d81441ac62379c5306f2f2d8b0894d06ec\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@196bc4e292571973969179d7d48e687a2720bb2f\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
+++ b/tutorials/pyhpc/notebooks/05__book_histogram__kernel_authoring.ipynb
@@ -46,7 +46,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -42,7 +42,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@196bc4e292571973969179d7d48e687a2720bb2f\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -42,7 +42,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@fa9ee4d81441ac62379c5306f2f2d8b0894d06ec\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -42,7 +42,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -407,7 +407,7 @@
     "\n",
     "Our asynchronous implementation overlaps checkpoint I/O on the CPU with power-iteration steps on the GPU. `check_frequency` controls how many GPU steps run between residual checks and checkpoints. A smaller value produces output more frequently, but may not provide enough GPU work to hide the I/O. A larger value provides more GPU work to overlap with the I/O, but delays output and convergence checks.\n",
     "\n",
-    "**SOLUTION:** Sweep check frequencies from 20 through 30 in increments of 1 and determine the output frequency with the lowest execution time. Reuse the same matrix and time only `estimate_device_async`, so matrix setup remains outside the measurement."
+    "**SOLUTION:** Sweep check frequencies from 20 through 35 in increments of 1 and determine the output frequency with the lowest execution time. Reuse the same matrix and benchmark `estimate_device_async` with progress disabled, so matrix setup remains outside the measurement."
    ]
   },
   {
@@ -417,7 +417,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "check_frequencies = list(range(20, 31))\n",
+    "check_frequencies = list(range(20, 36))\n",
     "async_durations = []\n",
     "\n",
     "print(\"Sweeping async check frequencies...\")\n",
@@ -427,7 +427,10 @@
     "\n",
     "for check_frequency in check_frequencies:\n",
     "    cfg = PowerIterationConfig(check_frequency=check_frequency, progress=False)\n",
-    "    _, duration_ms = time_estimator(estimate_device_async, cfg)\n",
+    "    timing = cpx.profiler.benchmark(\n",
+    "        estimate_device_async, (A_device, cfg), n_repeat=5, n_warmup=1\n",
+    "    )\n",
+    "    duration_ms = timing.cpu_times.mean() * 1000\n",
     "    async_durations.append(duration_ms)\n",
     "    print(f\"{check_frequency:>18} | {duration_ms:>9.3f} ms\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -42,7 +42,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -42,7 +42,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -42,7 +42,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -42,7 +42,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -42,7 +42,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -50,11 +50,10 @@
     "import cupy as cp\n",
     "import cupyx as cpx\n",
     "import nvtx\n",
-    "import time\n",
     "from dataclasses import dataclass\n",
     "from jupyter_dark_detect import is_dark\n",
     "import matplotlib.pyplot as plt\n",
-    "plt.style.use('dark_background' if is_dark() else 'default')\n"
+    "plt.style.use('dark_background' if is_dark() else 'default')"
    ]
   },
   {
@@ -82,15 +81,13 @@
     "\n",
     "We will start with a baseline implementation of the Power Iteration algorithm.\n",
     "\n",
-    "The setup below mirrors the previous memory-spaces notebook: one configuration, one generated matrix, and one estimator function. The Nsight Systems kernel lets us profile these ordinary notebook cells directly.\n",
-    "\n",
-    "**SOLUTION:** The baseline code below already includes NVTX annotations and `cpx.profiler.profile()` to demonstrate the proper profiling setup."
+    "The setup below mirrors the previous memory-spaces notebook: one configuration, one generated matrix, and one estimator function. The Nsight Systems kernel lets us profile these ordinary notebook cells directly."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4b62fef",
+   "id": "7dd38317",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,44 +98,79 @@
     "  max_steps: int = 400\n",
     "  check_frequency: int = 25\n",
     "  progress: bool = True\n",
-    "  residual_threshold: float = 1e-10\n",
-    "\n",
+    "  residual_threshold: float = 1e-10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81b3f4c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def generate_device(cfg=PowerIterationConfig()):\n",
     "  cp.random.seed(42)\n",
     "  weak_lam = cp.random.random(cfg.dim - 1) * (1.0 - cfg.dominance)\n",
     "  lam = cp.random.permutation(cp.concatenate((cp.asarray([1.0]), weak_lam)))\n",
     "  P = cp.random.random((cfg.dim, cfg.dim))\n",
     "  D = cp.diag(cp.random.permutation(lam))\n",
-    "  return (P @ D) @ cp.linalg.inv(P)\n",
-    "\n",
+    "  return (P @ D) @ cp.linalg.inv(P)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f083598a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A_device = generate_device()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8cdd65d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def estimate_device_baseline(A, cfg=PowerIterationConfig()) -> np.ndarray:\n",
-    "  A_gpu = cp.asarray(A)\n",
-    "  x = cp.ones(A_gpu.shape[0], dtype=np.float64)\n",
+    "  with nvtx.annotate(\"Setup\"):\n",
+    "    A_gpu = cp.asarray(A)\n",
+    "    x = cp.ones(A_gpu.shape[0], dtype=np.float64)\n",
     "\n",
-    "  for i in range(0, cfg.max_steps, cfg.check_frequency):\n",
-    "    y = A_gpu @ x\n",
-    "    lam = (x @ y) / (x @ x)\n",
-    "    res = cp.linalg.norm(y - lam * x)\n",
-    "    x = y / cp.linalg.norm(y)\n",
+    "  with nvtx.annotate(\"Loop\"):\n",
+    "    for i in range(0, cfg.max_steps, cfg.check_frequency):\n",
+    "      with nvtx.annotate(f\"Step {i} to {i + cfg.check_frequency}\"):\n",
+    "        with nvtx.annotate(f\"Compute & Residual {i}\"):\n",
+    "          y = A_gpu @ x\n",
+    "          lam = (x @ y) / (x @ x)\n",
+    "          res = cp.linalg.norm(y - lam * x)\n",
+    "          x = y / cp.linalg.norm(y)\n",
     "\n",
-    "    if cfg.progress:\n",
-    "      print(f\"step {i}: residual = {res:.3e}\")\n",
+    "        with nvtx.annotate(f\"Copy {i}\"):\n",
+    "          x_host = cp.asnumpy(x)\n",
     "\n",
-    "    np.savetxt(f\"/tmp/device_{i}.txt\", cp.asnumpy(x))\n",
-    "    if res < cfg.residual_threshold:\n",
-    "      break\n",
+    "        with nvtx.annotate(f\"I/O {i}\", payload=i):\n",
+    "          if cfg.progress:\n",
+    "            print(f\"step {i}: residual = {res:.3e}\")\n",
+    "          np.savetxt(f\"/tmp/device_{i}.txt\", x_host)\n",
     "\n",
-    "    for _ in range(i + 1, min(i + cfg.check_frequency, cfg.max_steps)):\n",
-    "      y = A_gpu @ x\n",
-    "      x = y / cp.linalg.norm(y)\n",
+    "        if res < cfg.residual_threshold:\n",
+    "          break\n",
+    "\n",
+    "        with nvtx.annotate(f\"Compute {i + 1} to {i + cfg.check_frequency}\"):\n",
+    "          for j in range(i + 1, min(i + cfg.check_frequency, cfg.max_steps)):\n",
+    "            with nvtx.annotate(f\"Compute Step {j}\"):\n",
+    "              y = A_gpu @ x\n",
+    "              x = y / cp.linalg.norm(y)\n",
     "\n",
     "  return cp.asnumpy((x.T @ (A_gpu @ x)) / (x.T @ x))\n",
     "\n",
-    "A_device = generate_device()\n",
     "estimate_device_baseline(\n",
     "  A_device,\n",
     "  cfg=PowerIterationConfig(max_steps=1, check_frequency=1, progress=False),\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -148,7 +180,7 @@
    "source": [
     "### 4. Profiling the Baseline\n",
     "\n",
-    "Select the **Python 3 (Nsight Systems)** kernel, then profile the baseline in place. The `%%nsys` magic collects only this cell and displays the resulting timeline without restarting the kernel."
+    "This notebook uses the **Python 3 (Nsight Systems)** kernel so we can profile the baseline in place. The `%%nsys` magic collects only this cell and displays the resulting timeline without restarting the kernel."
    ]
   },
   {
@@ -160,7 +192,7 @@
    "source": [
     "%%nsys -o power_iteration__baseline.nsys-rep\n",
     "lam_est_baseline = estimate_device_baseline(A_device)\n",
-    "np.testing.assert_allclose(lam_est_baseline, 1, atol=1e-4)\n"
+    "np.testing.assert_allclose(lam_est_baseline, 1, atol=1e-4)"
    ]
   },
   {
@@ -190,37 +222,16 @@
    "source": [
     "### 5. Better Visibility with NVTX\n",
     "\n",
-    "Nsight Systems shows us a lot of information - sometimes it's too much and not all relevant.\n",
-    "\n",
-    "There's two ways that we can filter and annotate what we see in Nsight systems.\n",
-    "\n",
-    "The first is to limit when we start and stop profiling in the program. In Python, we can do this with `cupyx.profiler.profile()`, which give us a Python context manager. Any CUDA code used during scope will be included in the profile.\n",
-    "\n",
-    "```\n",
-    "not_in_the_profile()\n",
-    "with cpx.profiler.profile():\n",
-    "  in_the_profile()\n",
-    "not_in_the_profile()\n",
-    "```\n",
-    "\n",
-    "For this to work, we have to pass `--capture-range=cudaProfilerApi --capture-range-end=stop` as flags to `nsys`.\n",
-    "\n",
-    "We can also annotate specific regions of our code, which will show up in the profiler. We can even add categories, domains, and colors to these regions, and they can be nested. To add these annotations, we use `nvtx.annotate()`, another Python context manager, this time from a library called NVTX.\n",
+    "Nsight Systems shows us a lot of information—sometimes too much, and not all of it is relevant. We can annotate specific regions of our code so they stand out in the timeline. These regions can have categories, domains, and colors, and they can be nested. To add them, use the `nvtx.annotate()` context manager:\n",
     "\n",
     "```\n",
     "with nvtx.annotate(\"Loop\"):\n",
     "  for i in range(20):\n",
-    "     with nvtx.annotate(f\"Step {i}\"):\n",
-    "       pass\n",
+    "    with nvtx.annotate(f\"Step {i}\"):\n",
+    "      pass\n",
     "```\n",
     "\n",
-    "**SOLUTION:** The baseline code above already includes:\n",
-    "\n",
-    "- `nvtx.annotate()` regions for \"Setup\", \"Loop\", \"Step\", \"Compute & Residual\", \"Copy\", \"I/O\", and \"Compute\" phases.\n",
-    "\n",
-    "- A `cpx.profiler.profile()` around the timing section.\n",
-    "\n",
-    "- The `nsys` command includes `--capture-range=cudaProfilerApi --capture-range-end=stop` flags.\n",
+    "**SOLUTION:** The baseline code above includes `nvtx.annotate()` regions for the setup, loop, step, compute and residual, copy, I/O, and compute phases.\n",
     "\n",
     "From our profile trace, we can see that both our CPU and GPU are idly waiting for each other! Device code is idle during every I/O step when we print the residual and write the checkpoint, and host code spends a long time synchronizing on `cudaMemcpyAsync`.\n",
     "\n",
@@ -232,9 +243,9 @@
     "\n",
     "This is inefficient; we can do better by overlapping compute and I/O:\n",
     "\n",
-    "- First, host code asynchronously initiate our device to host copies.\n",
-    "- Then, host code asynchronously launch the next set of compute steps on the device.\n",
-    "- Next, host code synchronize with the asynchronous copies we started.\n",
+    "- First, host code asynchronously initiates our device-to-host copies.\n",
+    "- Then, host code asynchronously launches the next set of compute steps on the device.\n",
+    "- Next, host code synchronizes with the asynchronous copies we started.\n",
     "- Finally, the host performs the I/O while the device performs the next set of compute steps.\n",
     "\n",
     "Everything is still going to run on one stream, but we want to be able to synchronize with just the I/O, which is launched on the stream before the compute work. We'll use a CUDA event, which we will record on the stream right after the copy. Then, we can synchronize with the event later, waiting for the I/O but not the compute!"
@@ -304,7 +315,7 @@
     "          if res_host < cfg.residual_threshold:\n",
     "            break\n",
     "\n",
-    "  return cp.asnumpy((x.T @ (A_gpu @ x)) / (x.T @ x)) # Copy from device to host.\n"
+    "  return cp.asnumpy((x.T @ (A_gpu @ x)) / (x.T @ x)) # Copy from device to host."
    ]
   },
   {
@@ -323,7 +334,7 @@
    "outputs": [],
    "source": [
     "lam_est_async = estimate_device_async(A_device)\n",
-    "np.testing.assert_allclose(lam_est_async, 1, atol=1e-4)\n"
+    "np.testing.assert_allclose(lam_est_async, 1, atol=1e-4)"
    ]
   },
   {
@@ -343,21 +354,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def time_estimator(estimator, cfg):\n",
-    "  cp.cuda.get_current_stream().synchronize()\n",
-    "  start = time.perf_counter()\n",
-    "  result = estimator(A_device, cfg=cfg)\n",
-    "  cp.cuda.get_current_stream().synchronize()\n",
-    "  return result, (time.perf_counter() - start) * 1000\n",
-    "\n",
     "quiet_cfg = PowerIterationConfig(progress=False)\n",
-    "_, power_iteration_baseline_duration = time_estimator(estimate_device_baseline, quiet_cfg)\n",
-    "_, power_iteration_async_duration = time_estimator(estimate_device_async, quiet_cfg)\n",
+    "power_iteration_baseline_duration = cpx.profiler.benchmark(\n",
+    "  estimate_device_baseline, (A_device, quiet_cfg), n_repeat=5, n_warmup=1\n",
+    ").cpu_times.mean() * 1000\n",
+    "power_iteration_async_duration = cpx.profiler.benchmark(\n",
+    "  estimate_device_async, (A_device, quiet_cfg), n_repeat=5, n_warmup=1\n",
+    ").cpu_times.mean() * 1000\n",
     "speedup = power_iteration_baseline_duration / power_iteration_async_duration\n",
     "\n",
     "print(f\"power_iteration_baseline: {power_iteration_baseline_duration:.3f} ms\")\n",
     "print(f\"power_iteration_async:    {power_iteration_async_duration:.3f} ms\")\n",
-    "print(f\"power_iteration_async speedup over power_iteration_baseline: {speedup:.2f}\")\n"
+    "print(f\"power_iteration_async speedup over power_iteration_baseline: {speedup:.2f}\")"
    ]
   },
   {
@@ -377,7 +385,7 @@
    "source": [
     "%%nsys -o power_iteration__async.nsys-rep\n",
     "lam_est_async = estimate_device_async(A_device)\n",
-    "np.testing.assert_allclose(lam_est_async, 1, atol=1e-4)\n"
+    "np.testing.assert_allclose(lam_est_async, 1, atol=1e-4)"
    ]
   },
   {
@@ -434,7 +442,7 @@
     "    async_durations.append(duration_ms)\n",
     "    print(f\"{check_frequency:>18} | {duration_ms:>9.3f} ms\")\n",
     "\n",
-    "print(\"=\" * 45)\n"
+    "print(\"=\" * 45)"
    ]
   },
   {
@@ -484,7 +492,7 @@
     "%%nsys -o power_iteration__async__optimal.nsys-rep\n",
     "optimal_cfg = PowerIterationConfig(check_frequency=optimal_check_frequency)\n",
     "lam_est_optimal = estimate_device_async(A_device, cfg=optimal_cfg)\n",
-    "np.testing.assert_allclose(lam_est_optimal, 1, atol=1e-4)\n"
+    "np.testing.assert_allclose(lam_est_optimal, 1, atol=1e-4)"
    ]
   }
  ],
@@ -496,9 +504,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Nsight Systems)",
    "language": "python",
-   "name": "python3"
+   "name": "nsightful-nsys"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/03__power_iteration__cupy__asynchrony__SOLUTION.ipynb
@@ -42,7 +42,7 @@
     "  print(\"Installing Nsight Systems package.\")\n",
     "  !dpkg -i NsightSystems-linux-cli-public-2026.1.1.204-3717666.deb > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
+    "  !pip install \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -54,7 +54,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -54,7 +54,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -54,7 +54,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@fa9ee4d81441ac62379c5306f2f2d8b0894d06ec\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -54,7 +54,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -54,7 +54,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -54,7 +54,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -731,9 +731,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Nsight Compute)",
    "language": "python",
-   "name": "python3"
+   "name": "nsightful-ncu"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -54,7 +54,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@196bc4e292571973969179d7d48e687a2720bb2f\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -54,7 +54,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/04__copy__kernel_authoring__SOLUTION.ipynb
@@ -54,7 +54,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -53,7 +53,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -53,7 +53,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -901,9 +901,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Nsight Compute)",
    "language": "python",
-   "name": "python3"
+   "name": "nsightful-ncu"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -53,7 +53,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2dfd77bd467dd2c5dd19707fec554180f663843b\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -53,7 +53,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@3cbb5ad159ccc31b1dc433142d857f4c2d1b0059\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -53,7 +53,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@196bc4e292571973969179d7d48e687a2720bb2f\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@1cdeaab47f823aac6e25b05251420f540ab0db42\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -53,7 +53,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@2e59cafafc9c3ba7a11740d82f79cfa11d47ee3c\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -53,7 +53,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@459e5735a45feeb6e953e3cd40efb09a453c1e7d\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -53,7 +53,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@9b4781851e2560a2f056340c86fa52ecf9375da2\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@db539f48384fa8618055921cdff62cf3fef1070f\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",

--- a/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
+++ b/tutorials/pyhpc/notebooks/solutions/05__book_histogram__kernel_authoring__SOLUTION.ipynb
@@ -53,7 +53,7 @@
     "  print(\"Uninstalling PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  print(\"Installing PIP packages.\")\n",
-    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/robobryce/nsightful.git@b85903a1209358fe60d881a42a446481e9ba73c5\" > /dev/null 2>&1\n",
+    "  !pip install \"numba-cuda\" \"cuda-cccl[test-cu12]\" \"nvtx\" \"nsightful[notebook] @ git+https://github.com/brycelelbach/nsightful.git@fa9ee4d81441ac62379c5306f2f2d8b0894d06ec\" > /dev/null 2>&1\n",
     "  open(\"/accelerated-computing-hub-installed\", \"a\").close()\n",
     "  print(\"All packages installed.\")\n",
     "\n",


### PR DESCRIPTION
## Summary

- make the PyHPC asynchrony exercise and solution open with the installed Nsight Systems kernel by default
- make the copy and histogram exercises and solutions open with the installed Nsight Compute kernel by default
- permit any notebook to use an exact approved kernelspec instead of maintaining per-notebook exceptions
- split configuration, device data generation, matrix creation, and the baseline estimator into separate teaching cells
- replace manual `time.perf_counter()` timing with `cupyx.profiler.benchmark()`
- remove obsolete `cupyx.profiler.profile()` and CUDA profiler capture-range instructions while retaining the NVTX lesson
- sweep async check frequencies from 20 through 35 with progress disabled
- remove trailing blank lines from code cells, including profiler-magic cells
- use the merged Nsight Systems 2026.1.1 interactive-session readiness fix from [nsightful#3](https://github.com/brycelelbach/nsightful/pull/3)

## Validation

- `python3 brev/test-notebook-format.py` (all 152 notebooks)
- focused pre-commit notebook-format checks
- exact local equivalents of ACH YAML, Git LFS, commit-signature, and diff-hygiene checks
- all 12 PR commits are GitHub-verified
- merged Nsightful commit installs successfully from `brycelelbach/nsightful` and exposes the session-readiness path with no callback fallback
- Nsightful CI passes on Python 3.10, 3.11, and 3.12
- final fresh CSCS GH200 test in the published PyHPC tutorial container:
  - Notebook 03 solution completed under `nsightful-nsys` in 59.3 seconds, including three `%%nsys` reports, CuPy benchmarks, and the 20–35 sweep
  - Notebook 04 solution completed under `nsightful-ncu` in 16.3 seconds, including both NCU profiles
  - Notebook 05 solution completed under `nsightful-ncu` in 13.1 seconds, including both NCU profiles
- verified the container-owned profiler binaries and paths:
  - Nsight Systems 2026.1.1 at `ACH_NSYS_PATH`
  - Nsight Compute 2025.4.1 at `ACH_NCU_PATH`
  - ACH profiler wrappers first on `PATH`
