### PR TITLE
Start CSCS web services concurrently

### DIFF
--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -429,8 +429,13 @@ stop_services() {
     if [ "${#pids[@]}" -gt 0 ]; then
         kill "${pids[@]}" 2>/dev/null || true
     fi
+    local -a cleanup_pids=()
     for store in main nsys ncu; do
-        clean_store "${store}"
+        clean_store "${store}" &
+        cleanup_pids+=("$!")
+    done
+    for pid in "${cleanup_pids[@]}"; do
+        wait "${pid}" 2>/dev/null || true
     done
     for pid in "${pids[@]}"; do
         wait "${pid}" 2>/dev/null || true
@@ -469,10 +474,9 @@ with_store main "${COMPOSE}" --podman-run-args=--cgroups=disabled \
     -e "TURN_USERNAME=${TURN_USERNAME}" -e "TURN_PASSWORD=${TURN_PASSWORD}" \
     base
 
-start_service() {
+launch_service() {
     local service=$1
     local store=$2
-    local url=$3
     local log="${RUN_STATE}/${service}.log"
 
     (
@@ -507,6 +511,12 @@ start_service() {
     local pid=$!
     chmod 600 "${log}"
     pids+=("${pid}")
+}
+
+wait_for_service() {
+    local service=$1
+    local url=$2
+    local log="${RUN_STATE}/${service}.log"
 
     local deadline=$((SECONDS + 300))
     while [ "${SECONDS}" -lt "${deadline}" ]; do
@@ -526,6 +536,16 @@ start_service() {
     return 1
 }
 
+start_services() {
+    launch_service jupyter main
+    launch_service nsys nsys
+    launch_service ncu ncu
+
+    wait_for_service jupyter http://127.0.0.1:8888/api/status &&
+        wait_for_service nsys http://127.0.0.1:8080/health &&
+        wait_for_service ncu http://127.0.0.1:8081/health
+}
+
 generation=0
 ready_announced=0
 while true; do
@@ -538,9 +558,7 @@ while true; do
             >>"${RUN_STATE}/${service}.log"
     done
 
-    if ! start_service jupyter main http://127.0.0.1:8888/api/status || \
-       ! start_service nsys nsys http://127.0.0.1:8080/health || \
-       ! start_service ncu ncu http://127.0.0.1:8081/health; then
+    if ! start_services; then
         echo "Web service generation ${generation} failed during startup; restarting all services." >&2
         stop_services
         sleep 5


### PR DESCRIPTION
## Summary

- launch JupyterLab, Nsight Systems, and Nsight Compute concurrently in each CSCS service generation
- clean the three isolated rootless Podman stores concurrently between generations
- retain the existing contract that any web-service exit restarts the complete group

## Root cause

PR #232 did restart all three services, but its recovery path was serialized twice: it cleaned the three Podman stores one at a time, then started and waited for Jupyter, NSYS, and NCU one at a time. On the reported job 4276695, File → Shut Down at `2026-07-26 07:57:51 UTC` produced generation 2 at `07:58:16` (Jupyter), `07:58:19` (NSYS), and `07:58:22` (NCU). During that roughly 30-second rolling outage, SSH forwards correctly reported repeated `connect failed: Connection refused`, making the deployment appear dead even though the Slurm job remained running.

## Live Daint validation

Tested the exact patched runtime from signed commit `6a1d58e` in job **4276808** on **nid006450**, using the real CSCS launcher, published PyHPC image, three isolated Podman stores, and Jupyter's XSRF-protected `/api/shutdown` endpoint (the File → Shut Down action).

- generation 1 IDs: Jupyter `2d2771079ea0`, NSYS `e1aea2a6fddf`, NCU `caec8c42d3a1`
- first shutdown returned HTTP 200; all three endpoints recovered in **14.84 s**
- generation 2 IDs: Jupyter `c96449e276d3`, NSYS `0382a483d456`, NCU `47153014267a`
- second shutdown returned HTTP 200; all three endpoints recovered in **14.06 s**
- generation 3 IDs: Jupyter `16be49f868fb`, NSYS `33242a58aedc`, NCU `b6e0f9d0ed18`
- after both cycles, `:8888/api/status`, `:8080/health`, and `:8081/health` returned HTTP 200
- Slurm job 4276808 remained `RUNNING` through generation 3; the launcher logged all three services ready after both restarts
- all test allocations created for this investigation were canceled afterward

This cuts the observed complete recovery from about 30 seconds to about 14–15 seconds while still replacing all three service containers and keeping the same Slurm allocation and SSH forwarding path.

## Local validation

- `bash -n tutorials/pyhpc/brev/cscs-launch-tutorial.bash`
- `shellcheck tutorials/pyhpc/brev/cscs-launch-tutorial.bash`
- `git diff --check`
- repository hooks for the changed file
- signed commit and pre-push signature verification

`pre-commit run --all-files` additionally found pre-existing canonical-format failures in `events/pycon_2025/ai_with_a_conscience.ipynb` and `docs/notebook_template.ipynb`; neither is touched by this PR.
