### PR TITLE
Ignore untracked files when updating CSCS checkout

### DIFF
--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -52,7 +52,7 @@ prepare_checkout() {
         fi
 
         local status
-        if ! status=$(git -C "${repo}" status --porcelain=v1 --untracked-files=all); then
+        if ! status=$(git -C "${repo}" status --porcelain=v1 --untracked-files=no); then
             echo "Error: could not inspect the existing checkout: ${repo}" >&2
             return 1
         fi
@@ -113,7 +113,7 @@ prepare_runtime_checkout() {
         return 1
     fi
     local status
-    if ! status=$(git -C "${repo}" status --porcelain=v1 --untracked-files=all); then
+    if ! status=$(git -C "${repo}" status --porcelain=v1 --untracked-files=no); then
         echo "Error: could not inspect managed runtime checkout: ${repo}" >&2
         return 1
     fi


### PR DESCRIPTION
## Summary

Allow the CSCS launcher to update the student and managed runtime checkouts when they contain only untracked files. Tracked modifications still make the checkout dirty and prevent an update.

## Validation

- verified `git status --porcelain=v1 --untracked-files=no` ignores an untracked file
- verified it still reports a tracked modification
- pre-commit hooks and commit-signature checks pass