### PR TITLE
Install PyHPC profiler kernels in Jupyter search path

### DIFF
--- a/tutorials/pyhpc/brev/dockerfile
+++ b/tutorials/pyhpc/brev/dockerfile
@@ -163,8 +163,14 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 # Install profiler-backed kernels for in-place notebook cell profiling.
-RUN nsightful-ncu install --sys-prefix '--profiler-args=--set full --clock-control none' \
- && nsightful-nsys install --sys-prefix '--profiler-args=--trace=cuda,nvtx,osrt'
+RUN nsightful-ncu install --prefix /usr/local '--profiler-args=--set full --clock-control none' \
+ && nsightful-nsys install --prefix /usr/local '--profiler-args=--trace=cuda,nvtx,osrt' \
+ && chmod -R a+rX /usr/local/share/jupyter/kernels/nsightful-ncu \
+                    /usr/local/share/jupyter/kernels/nsightful-nsys \
+ && su -s /bin/sh nobody -c 'HOME=/tmp python -m jupyter kernelspec list --json' \
+      | grep -q 'nsightful-ncu' \
+ && su -s /bin/sh nobody -c 'HOME=/tmp python -m jupyter kernelspec list --json' \
+      | grep -q 'nsightful-nsys'
 
 # Disable unnecessary default Jupyter extensions.
 RUN python -m jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \


### PR DESCRIPTION
## Summary

Install the Nsightful kernelspecs under `/usr/local/share/jupyter/kernels`, make them readable/traversable by non-root users, and verify during the Docker build that an unprivileged user can discover both kernels.

## Failure fixed

Event-head PyHPC CI run 30199357352 failed because the base test container could not find `nsightful-nsys` or `nsightful-ncu`. Inspection of the published image showed that `nsightful install --sys-prefix` placed the kernels under `/usr/share/jupyter/kernels` with root-owned `0700` directories. The non-root CI user could not traverse them.

## Validation

- inspected the exact published image layer and confirmed the old root-owned `0700` kernelspec directories
- the Docker build now checks kernel discovery using the unprivileged `nobody` user
- pre-commit and commit-signature checks pass
- full CI image rebuild/test required because this changes the Docker image