### PR TITLE
Use one checkout for PyHPC CSCS containers

### DIFF
--- a/brev/prepare-podman-compose.py
+++ b/brev/prepare-podman-compose.py
@@ -87,24 +87,16 @@ def find_nvidia_devices():
     ]
 
 
-def replace_repo_volume(data, repo_root, notebooks_root=""):
-    """Bind the runtime checkout and, optionally, a persistent notebook tree."""
+def replace_repo_volume(data, repo_root):
+    """Bind one checkout as the container repository."""
     volume_name = "accelerated-computing-hub"
     bind_mount = f"{repo_root}:/accelerated-computing-hub"
-    notebooks_mount = ""
-    if notebooks_root:
-        notebooks_mount = (
-            f"{notebooks_root}:"
-            "/accelerated-computing-hub/tutorials/pyhpc/notebooks"
-        )
     for service in (data.get("services") or {}).values():
         volumes = service.get("volumes") or []
         service["volumes"] = [
             bind_mount if item == f"{volume_name}:/accelerated-computing-hub" else item
             for item in volumes
         ]
-        if notebooks_mount and notebooks_mount not in service["volumes"]:
-            service["volumes"].append(notebooks_mount)
         environment = service.get("environment") or {}
         if isinstance(environment, dict):
             environment.update({"ACH_USER": "root", "ACH_UID": "0", "ACH_GID": "0"})
@@ -226,11 +218,7 @@ def prepare(source, destination, repo_root="", bind_repo=False):
         all_services=os.environ.get("ACH_PODMAN_HOST_NETWORK") == "1",
     )
     if bind_repo and repo_root:
-        replace_repo_volume(
-            data,
-            repo_root,
-            notebooks_root=os.environ.get("ACH_PODMAN_NOTEBOOKS_ROOT", ""),
-        )
+        replace_repo_volume(data, repo_root)
     add_rootless_gpu_access(data)
 
     with open(destination, "w", encoding="utf-8") as handle:

--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -19,6 +19,7 @@ Options:
                          (default: event/2026-07-cscs-summer-school)
   --state PATH           Deployment state directory (default: $SCRATCH/ach-pyhpc-web)
   --partition NAME       Slurm partition (default: normal)
+  --reservation NAME     Slurm reservation (default: $CSCS_RESERVATION, if set)
   --time DURATION        Slurm duration (default: 10:00:00)
   --start-timeout SEC    Time to wait for READY (default: 1800)
   -h, --help             Show this help
@@ -206,6 +207,7 @@ login_main() {
     local branch=${ACH_BRANCH:-event/2026-07-cscs-summer-school}
     local state_dir=${ACH_STATE:-${SCRATCH}/ach-pyhpc-web}
     local partition=${CSCS_PARTITION:-normal}
+    local reservation=${CSCS_RESERVATION:-}
     local duration=${CSCS_TIME:-10:00:00}
     local start_timeout=${ACH_START_TIMEOUT:-1800}
 
@@ -216,6 +218,7 @@ login_main() {
             --branch) branch=${2:?--branch requires a value}; shift 2 ;;
             --state) state_dir=${2:?--state requires a value}; shift 2 ;;
             --partition) partition=${2:?--partition requires a value}; shift 2 ;;
+            --reservation) reservation=${2:?--reservation requires a value}; shift 2 ;;
             --time) duration=${2:?--time requires a value}; shift 2 ;;
             --start-timeout) start_timeout=${2:?--start-timeout requires a value}; shift 2 ;;
             -h|--help) usage; return 0 ;;
@@ -265,6 +268,9 @@ login_main() {
         "--export=ALL,ACH_REPO=${repo},ACH_STATE=${state_dir},ACH_RELEASE_BRANCH=${branch}"
     )
     sbatch_args+=(--account="${account}")
+    if [ -n "${reservation}" ]; then
+        sbatch_args+=(--reservation="${reservation}")
+    fi
 
     local job_id
     job_id=$(sbatch "${sbatch_args[@]}" "${batch_script}" --batch)

--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -304,7 +304,7 @@ ACH_REPO=${ACH_REPO:?ACH_REPO is not set}
 ACH_STATE=${ACH_STATE:-${SCRATCH:?SCRATCH is not set}/ach-pyhpc-web}
 ACH_RELEASE_BRANCH=${ACH_RELEASE_BRANCH:?ACH_RELEASE_BRANCH is not set}
 COMPOSE_URL=${ACH_COMPOSE_URL:-https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/generated/${ACH_RELEASE_BRANCH}/tutorials/pyhpc/brev/docker-compose.yml}
-PREPARE_URL=${ACH_PREPARE_URL:-https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/${ACH_RELEASE_BRANCH}/brev/prepare-podman-compose.py}
+PREPARE_SOURCE=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)/prepare-podman-compose.py
 
 if [ ! -d "${ACH_REPO}/tutorials/pyhpc/notebooks" ]; then
     echo "Error: student checkout has no PyHPC notebooks: ${ACH_REPO}" >&2
@@ -321,8 +321,11 @@ PODMAN_COMPOSE="${RUN_STATE}/docker-compose.podman.yml"
 PREPARE_SCRIPT="${RUN_STATE}/prepare-podman-compose.py"
 curl --fail --location --retry 3 --silent --show-error \
     "${COMPOSE_URL}" --output "${SOURCE_COMPOSE}"
-curl --fail --location --retry 3 --silent --show-error \
-    "${PREPARE_URL}" --output "${PREPARE_SCRIPT}"
+if [ ! -f "${PREPARE_SOURCE}" ]; then
+    echo "Error: missing compose adapter: ${PREPARE_SOURCE}" >&2
+    exit 1
+fi
+cp "${PREPARE_SOURCE}" "${PREPARE_SCRIPT}"
 
 PYTHON=$(command -v python3.11 || command -v python3)
 VENV="${RUN_STATE}/venv"

--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -18,7 +18,6 @@ Options:
   --branch BRANCH        Release and new-checkout branch
                          (default: event/2026-07-cscs-summer-school)
   --state PATH           Deployment state directory (default: $SCRATCH/ach-pyhpc-web)
-  --runtime-repo PATH    Pre-existing release runtime checkout (advanced)
   --partition NAME       Slurm partition (default: normal)
   --time DURATION        Slurm duration (default: 10:00:00)
   --start-timeout SEC    Time to wait for READY (default: 1800)
@@ -89,40 +88,6 @@ prepare_checkout() {
         echo "Error: the checkout must be on a branch: ${repo}" >&2
         return 1
     fi
-}
-
-prepare_runtime_checkout() {
-    local repo=$1
-    local branch=$2
-
-    if [ ! -e "${repo}" ]; then
-        mkdir -p "$(dirname "${repo}")"
-        echo "Cloning the ${branch} runtime into ${repo}..."
-        git clone --depth 1 --branch "${branch}" \
-            https://github.com/NVIDIA/accelerated-computing-hub.git "${repo}"
-        return
-    fi
-    if ! git -C "${repo}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        echo "Error: managed runtime path is not a Git checkout: ${repo}" >&2
-        return 1
-    fi
-    local runtime_branch
-    runtime_branch=$(git -C "${repo}" branch --show-current)
-    if [ "${runtime_branch}" != "${branch}" ]; then
-        echo "Error: managed runtime checkout is on ${runtime_branch}, expected ${branch}: ${repo}" >&2
-        return 1
-    fi
-    local status
-    if ! status=$(git -C "${repo}" status --porcelain=v1 --untracked-files=no); then
-        echo "Error: could not inspect managed runtime checkout: ${repo}" >&2
-        return 1
-    fi
-    if [ -n "${status}" ]; then
-        echo "Error: managed runtime checkout is unexpectedly modified: ${repo}" >&2
-        return 1
-    fi
-    echo "Fast-forwarding the managed ${branch} runtime..."
-    git -C "${repo}" pull --ff-only origin "${branch}"
 }
 
 queue_state() {
@@ -240,7 +205,6 @@ login_main() {
     local repo=${ACH_REPO:-${SCRATCH:?SCRATCH is not set}/accelerated-computing-hub}
     local branch=${ACH_BRANCH:-event/2026-07-cscs-summer-school}
     local state_dir=${ACH_STATE:-${SCRATCH}/ach-pyhpc-web}
-    local runtime_repo=${ACH_RUNTIME_REPO:-}
     local partition=${CSCS_PARTITION:-normal}
     local duration=${CSCS_TIME:-10:00:00}
     local start_timeout=${ACH_START_TIMEOUT:-1800}
@@ -251,7 +215,6 @@ login_main() {
             --repo) repo=${2:?--repo requires a value}; shift 2 ;;
             --branch) branch=${2:?--branch requires a value}; shift 2 ;;
             --state) state_dir=${2:?--state requires a value}; shift 2 ;;
-            --runtime-repo) runtime_repo=${2:?--runtime-repo requires a value}; shift 2 ;;
             --partition) partition=${2:?--partition requires a value}; shift 2 ;;
             --time) duration=${2:?--time requires a value}; shift 2 ;;
             --start-timeout) start_timeout=${2:?--start-timeout requires a value}; shift 2 ;;
@@ -280,14 +243,6 @@ login_main() {
 
     mkdir -p "${state_dir}"
     chmod 700 "${state_dir}"
-    if [ -z "${runtime_repo}" ]; then
-        local runtime_name=${branch//\//-}
-        runtime_repo="${state_dir}/runtime-${runtime_name}"
-        prepare_runtime_checkout "${runtime_repo}" "${branch}"
-    elif [ ! -f "${runtime_repo}/brev/prepare-podman-compose.py" ]; then
-        echo "Error: --runtime-repo is not an accelerated-computing-hub checkout: ${runtime_repo}" >&2
-        return 1
-    fi
 
     local batch_script
     batch_script=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)/$(basename "${BASH_SOURCE[0]}")
@@ -307,7 +262,7 @@ login_main() {
         --job-name=ach-pyhpc-web
         "--chdir=${repo}"
         "--output=${state_dir}/slurm-%j.log"
-        "--export=ALL,ACH_REPO=${repo},ACH_RUNTIME_REPO=${runtime_repo},ACH_STATE=${state_dir},ACH_RELEASE_BRANCH=${branch}"
+        "--export=ALL,ACH_REPO=${repo},ACH_STATE=${state_dir},ACH_RELEASE_BRANCH=${branch}"
     )
     sbatch_args+=(--account="${account}")
 
@@ -340,29 +295,28 @@ if [ -z "${SLURM_JOB_ID:-}" ]; then
 fi
 
 ACH_REPO=${ACH_REPO:?ACH_REPO is not set}
-ACH_RUNTIME_REPO=${ACH_RUNTIME_REPO:?ACH_RUNTIME_REPO is not set}
 ACH_STATE=${ACH_STATE:-${SCRATCH:?SCRATCH is not set}/ach-pyhpc-web}
 ACH_RELEASE_BRANCH=${ACH_RELEASE_BRANCH:?ACH_RELEASE_BRANCH is not set}
 COMPOSE_URL=${ACH_COMPOSE_URL:-https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/generated/${ACH_RELEASE_BRANCH}/tutorials/pyhpc/brev/docker-compose.yml}
+PREPARE_URL=${ACH_PREPARE_URL:-https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/${ACH_RELEASE_BRANCH}/brev/prepare-podman-compose.py}
 
-if [ ! -f "${ACH_RUNTIME_REPO}/brev/prepare-podman-compose.py" ]; then
-    echo "Error: ACH_RUNTIME_REPO is not an accelerated-computing-hub checkout: ${ACH_RUNTIME_REPO}" >&2
-    exit 1
-fi
 if [ ! -d "${ACH_REPO}/tutorials/pyhpc/notebooks" ]; then
     echo "Error: student checkout has no PyHPC notebooks: ${ACH_REPO}" >&2
     exit 1
 fi
 
 RUN_STATE="${ACH_STATE}/${SLURM_JOB_ID}"
-mkdir -p "${RUN_STATE}" "${ACH_RUNTIME_REPO}/logs"
+mkdir -p "${RUN_STATE}"
 chmod 700 "${ACH_STATE}" "${RUN_STATE}"
 SERVICE_EVENTS="${RUN_STATE}/service-events"
 
 SOURCE_COMPOSE="${RUN_STATE}/docker-compose.yml"
 PODMAN_COMPOSE="${RUN_STATE}/docker-compose.podman.yml"
+PREPARE_SCRIPT="${RUN_STATE}/prepare-podman-compose.py"
 curl --fail --location --retry 3 --silent --show-error \
     "${COMPOSE_URL}" --output "${SOURCE_COMPOSE}"
+curl --fail --location --retry 3 --silent --show-error \
+    "${PREPARE_URL}" --output "${PREPARE_SCRIPT}"
 
 PYTHON=$(command -v python3.11 || command -v python3)
 VENV="${RUN_STATE}/venv"
@@ -377,13 +331,12 @@ TURN_USERNAME="turn_$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9' | head -c 16)
 TURN_PASSWORD="$(openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c 32)"
 
 export ACH_PODMAN_HOST_NETWORK=1
-export ACH_PODMAN_NOTEBOOKS_ROOT="${ACH_REPO}/tutorials/pyhpc/notebooks"
 export JUPYTER_HOST=127.0.0.1
 export NSYS_HTTP_URL=http://127.0.0.1:8080
 export SELKIES_ENABLE_HTTPS=false
 
-"${VENV}/bin/python" "${ACH_RUNTIME_REPO}/brev/prepare-podman-compose.py" \
-    "${SOURCE_COMPOSE}" "${PODMAN_COMPOSE}" "${ACH_RUNTIME_REPO}" 1
+"${VENV}/bin/python" "${PREPARE_SCRIPT}" \
+    "${SOURCE_COMPOSE}" "${PODMAN_COMPOSE}" "${ACH_REPO}" 1
 
 JOB_ROOT="/dev/shm/${USER}/ach-pyhpc-web-${SLURM_JOB_ID}"
 mkdir -p "${JOB_ROOT}"

--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -66,11 +66,15 @@ prepare_checkout() {
                 "refs/heads/${requested_branch}"; then
                 if git -C "${repo}" merge-base --is-ancestor \
                     "refs/heads/${requested_branch}" "${remote_ref}"; then
-                    git -C "${repo}" switch "${requested_branch}"
+                    if [ "${branch}" != "${requested_branch}" ]; then
+                        git -C "${repo}" switch "${requested_branch}"
+                    fi
                     git -C "${repo}" merge --ff-only "${remote_ref}"
                 elif git -C "${repo}" merge-base --is-ancestor \
                     "${remote_ref}" "refs/heads/${requested_branch}"; then
-                    git -C "${repo}" switch "${requested_branch}"
+                    if [ "${branch}" != "${requested_branch}" ]; then
+                        git -C "${repo}" switch "${requested_branch}"
+                    fi
                 else
                     echo "Error: local ${requested_branch} cannot fast-forward to origin/${requested_branch}." >&2
                     echo "The checkout remains on ${branch}; resolve it manually or use a different --repo path." >&2

--- a/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-launch-tutorial.bash
@@ -249,8 +249,14 @@ login_main() {
 
     local batch_script
     batch_script=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)/$(basename "${BASH_SOURCE[0]}")
+    local prepare_source
+    prepare_source=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)/prepare-podman-compose.py
     if [ ! -x "${batch_script}" ]; then
         echo "Error: run an executable launcher file, not a pipe or process substitution." >&2
+        return 1
+    fi
+    if [ ! -f "${prepare_source}" ]; then
+        echo "Error: missing compose adapter: ${prepare_source}" >&2
         return 1
     fi
 
@@ -265,7 +271,7 @@ login_main() {
         --job-name=ach-pyhpc-web
         "--chdir=${repo}"
         "--output=${state_dir}/slurm-%j.log"
-        "--export=ALL,ACH_REPO=${repo},ACH_STATE=${state_dir},ACH_RELEASE_BRANCH=${branch}"
+        "--export=ALL,ACH_REPO=${repo},ACH_STATE=${state_dir},ACH_RELEASE_BRANCH=${branch},ACH_PREPARE_SOURCE=${prepare_source}"
     )
     sbatch_args+=(--account="${account}")
     if [ -n "${reservation}" ]; then
@@ -304,7 +310,7 @@ ACH_REPO=${ACH_REPO:?ACH_REPO is not set}
 ACH_STATE=${ACH_STATE:-${SCRATCH:?SCRATCH is not set}/ach-pyhpc-web}
 ACH_RELEASE_BRANCH=${ACH_RELEASE_BRANCH:?ACH_RELEASE_BRANCH is not set}
 COMPOSE_URL=${ACH_COMPOSE_URL:-https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/generated/${ACH_RELEASE_BRANCH}/tutorials/pyhpc/brev/docker-compose.yml}
-PREPARE_SOURCE=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)/prepare-podman-compose.py
+ACH_PREPARE_SOURCE=${ACH_PREPARE_SOURCE:?ACH_PREPARE_SOURCE is not set}
 
 if [ ! -d "${ACH_REPO}/tutorials/pyhpc/notebooks" ]; then
     echo "Error: student checkout has no PyHPC notebooks: ${ACH_REPO}" >&2
@@ -321,11 +327,11 @@ PODMAN_COMPOSE="${RUN_STATE}/docker-compose.podman.yml"
 PREPARE_SCRIPT="${RUN_STATE}/prepare-podman-compose.py"
 curl --fail --location --retry 3 --silent --show-error \
     "${COMPOSE_URL}" --output "${SOURCE_COMPOSE}"
-if [ ! -f "${PREPARE_SOURCE}" ]; then
-    echo "Error: missing compose adapter: ${PREPARE_SOURCE}" >&2
+if [ ! -f "${ACH_PREPARE_SOURCE}" ]; then
+    echo "Error: missing compose adapter: ${ACH_PREPARE_SOURCE}" >&2
     exit 1
 fi
-cp "${PREPARE_SOURCE}" "${PREPARE_SCRIPT}"
+cp "${ACH_PREPARE_SOURCE}" "${PREPARE_SCRIPT}"
 
 PYTHON=$(command -v python3.11 || command -v python3)
 VENV="${RUN_STATE}/venv"

--- a/tutorials/pyhpc/brev/cscs-run-tutorial.bash
+++ b/tutorials/pyhpc/brev/cscs-run-tutorial.bash
@@ -47,13 +47,15 @@ fi
 bootstrap_streamed_helpers() {
     local branch=${ACH_BRANCH:-event/2026-07-cscs-summer-school}
     local base_url=${ACH_CSCS_HELPER_BASE_URL:-https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/${branch}/tutorials/pyhpc/brev}
+    local prepare_url=${ACH_CSCS_PREPARE_URL:-https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/${branch}/brev/prepare-podman-compose.py}
     local helper_dir
     helper_dir=$(mktemp -d "${TMPDIR:-/tmp}/ach-cscs-helpers.XXXXXX")
 
     cleanup_downloads() {
         rm -f "${helper_dir}/cscs-run-tutorial.bash" \
             "${helper_dir}/cscs-launch-tutorial.bash" \
-            "${helper_dir}/cscs-connect-tutorial.bash"
+            "${helper_dir}/cscs-connect-tutorial.bash" \
+            "${helper_dir}/prepare-podman-compose.py"
         rmdir "${helper_dir}" >/dev/null 2>&1 || true
     }
     trap cleanup_downloads EXIT
@@ -68,6 +70,9 @@ bootstrap_streamed_helpers() {
             "${base_url}/${helper}" --output "${helper_dir}/${helper}"
         chmod 700 "${helper_dir}/${helper}"
     done
+    curl --fail --location --retry 3 --silent --show-error \
+        "${prepare_url}" --output "${helper_dir}/prepare-podman-compose.py"
+    chmod 700 "${helper_dir}/prepare-podman-compose.py"
     if ! { exec 3</dev/tty; } 2>/dev/null; then
         echo "Error: run this command from an interactive terminal." >&2
         exit 1
@@ -84,12 +89,17 @@ fi
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)
 launch_script="${script_dir}/cscs-launch-tutorial.bash"
 connect_script="${script_dir}/cscs-connect-tutorial.bash"
+prepare_script="${script_dir}/prepare-podman-compose.py"
 for script in "${launch_script}" "${connect_script}"; do
     if [ ! -x "${script}" ]; then
         echo "Error: missing executable sibling script: ${script}" >&2
         exit 1
     fi
 done
+if [ ! -x "${prepare_script}" ]; then
+    echo "Error: missing executable sibling script: ${prepare_script}" >&2
+    exit 1
+fi
 
 user=${CSCS_USER:-}
 ssh_key=${CSCS_SSH_KEY:-${HOME:?HOME is not set}/.ssh/cscs-key}
@@ -191,6 +201,8 @@ fi
 
 upload_command="umask 077; mkdir -p \"\$HOME/.local/share/accelerated-computing-hub\"; cat > \"\$HOME/.local/share/accelerated-computing-hub/cscs-launch-tutorial.bash\"; chmod 700 \"\$HOME/.local/share/accelerated-computing-hub/cscs-launch-tutorial.bash\""
 ssh -F "${ssh_config}" -S "${control_path}" ach-daint "${upload_command}" < "${launch_script}"
+upload_command="umask 077; cat > \"\$HOME/.local/share/accelerated-computing-hub/prepare-podman-compose.py\"; chmod 700 \"\$HOME/.local/share/accelerated-computing-hub/prepare-podman-compose.py\""
+ssh -F "${ssh_config}" -S "${control_path}" ach-daint "${upload_command}" < "${prepare_script}"
 
 remote_command="\"\$HOME/.local/share/accelerated-computing-hub/cscs-launch-tutorial.bash\""
 for arg in ${launch_args[@]+"${launch_args[@]}"}; do


### PR DESCRIPTION
## Root cause

The CSCS container was given a hybrid repository tree:

- the managed runtime checkout provided `/accelerated-computing-hub` and its `.git`
- the student checkout's notebook directory was nested over `/accelerated-computing-hub/tutorials/pyhpc/notebooks`

A `git pull` from a Jupyter terminal therefore updated the managed runtime's HEAD/index while writing notebook paths into the student checkout. The underlying runtime notebook files stayed at the old revision, so every later launch failed with `managed runtime checkout is unexpectedly modified`.

This is proven by the affected Daint checkout: the runtime index contains event head `7161916`, its underlying notebook files are exact blobs from older event commits, and the student checkout contains the new `7161916` blobs. The corrupting reflog entry is a plain in-container `pull: Fast-forward`, distinct from the launcher's `pull --ff-only origin ...` entries.

## Fix

- remove the managed runtime checkout entirely
- bind the complete student checkout at `/accelerated-computing-hub`
- remove the nested notebook bind mount
- download and upload the matching event-version compose adapter with the launcher helpers
- remove the `--runtime-repo` option and all `ACH_RUNTIME_REPO` plumbing
- add `--reservation NAME` / `CSCS_RESERVATION` support
- avoid a redundant `git switch` when already on the requested branch, which otherwise invokes a Git LFS hook on Daint

The result is one real Git checkout in the container and substantially less deployment machinery. Existing broken setups recover automatically: the legacy dirty runtime directory is neither inspected nor mounted and does not need to be removed.

## Validation

- shell syntax, Python compilation, pre-commit, and commit-signature hooks pass
- generated compose validation confirms every service has exactly one repository mount and no nested notebook mount
- exact workstation `cscs-run-tutorial.bash` workflow passed on job `4281545`, node `nid005497`
- Slurm recorded account `summerschool-course2026-cscs` and reservation `ss2026`
- JupyterLab, Nsight Systems, and Nsight Compute were reachable through the forwarded workstation ports
- inside Jupyter, the repository top-level, `.git`, and worktree all refer to the single student checkout
- the legacy runtime remained dirty throughout, proving existing broken installations recover automatically
