### PR TITLE
Tutorials/CUDA Tile: Add cuTile Python notebooks for matrix add, transpose, and activation functions

### DIFF
--- a/tutorials/cuda-tile/README.md
+++ b/tutorials/cuda-tile/README.md
@@ -15,3 +15,6 @@ Brev Launchables of this tutorial should use:
 | # | Topic | Solution | Technologies |
 |---|-------|----------|--------------|
 | 01 | [cuTile Python Intro: Vector Add](notebooks/01__cutile_python_intro__vector_add.ipynb) | - | cuTile Python |
+| 02 | [cuTile Python: Matrix Add](notebooks/02__cutile_python__matrix_add.ipynb) | - | cuTile Python |
+| 03 | [cuTile Python: Transpose](notebooks/03__cutile_python__transpose.ipynb) | - | cuTile Python |
+| 04 | [cuTile Python: Activation Functions](notebooks/04__cutile_python__activation_functions.ipynb) | - | cuTile Python |

--- a/tutorials/cuda-tile/notebooks/01__cutile_python_intro__vector_add.ipynb
+++ b/tutorials/cuda-tile/notebooks/01__cutile_python_intro__vector_add.ipynb
@@ -5,11 +5,11 @@
    "id": "90574f83-d15b-4970-a2e0-fae792b5ab21",
    "metadata": {},
    "source": [
-    "# cuTile Python Intro - Vector Add\n",
+    "# cuTile Python Intro: Vector Add\n",
     "\n",
     "In this module, you'll be introduced to the fundamentals of the CUDA Tile programming model and write your first kernel with cuTile Python.\n",
     "\n",
-    "cuTile Python is a Python DSL for writing CUDA Tile programs; it lowers to Tile IR, a new MLIR-based intermediate representation.\n"
+    "cuTile Python is a Python DSL for writing CUDA Tile programs; it lowers to Tile IR, a new MLIR-based intermediate representation."
    ]
   },
   {
@@ -23,7 +23,6 @@
     "\n",
     "    - NVIDIA Kernel Driver R580 or later.\n",
     "    - CUDA Toolkit 13.1 or later.\n",
-    "    - A Blackwell GPU (this restriction will be lifted in later releases).\n",
     "\n",
     "You can install cuTile Python via the PIP package `cuda-tile`."
    ]
@@ -37,11 +36,11 @@
    "source": [
     "import os\n",
     "\n",
-    "if not os.getenv(\"BREV_ENV_ID\") and not os.path.exists(\"/accelerated-computing-hub-installed\"): # If not running in brev\n",
+    "if not os.getenv(\"BREV_ENV_ID\") and not os.path.exists(os.path.expanduser(\"~/.accelerated-computing-hub-installed\")): # If not running in brev\n",
     "  print(\"Installing PIP packages.\")\n",
     "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
     "  !pip install \"cuda-tile\" \"cupy-cuda13x\" > /dev/null 2>&1\n",
-    "  open(\"/accelerated-computing-hub-installed\", \"a\").close()"
+    "  open(os.path.expanduser(\"~/.accelerated-computing-hub-installed\"), \"a\").close()"
    ]
   },
   {
@@ -115,6 +114,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0000-0000-000000000001",
+   "metadata": {},
+   "source": [
+    "The two kernels compute the same result but think about the problem differently.\n",
+    "\n",
+    "In `vector_add_simt`, the code runs once **per thread**. Each thread calculates its own position in the array and reads one element. With a 12-element array, 4 threads per block, and 1 item per thread:\n",
+    "\n",
+    "```\n",
+    "Block 0: thread 0 → C[0]=A[0]+B[0],  thread 1 → C[1]=A[1]+B[1],  ...\n",
+    "Block 1: thread 0 → C[4]=A[4]+B[4],  thread 1 → C[5]=A[5]+B[5],  ...\n",
+    "Block 2: thread 0 → C[8]=A[8]+B[8],  ...\n",
+    "```\n",
+    "\n",
+    "In `vector_add_tile`, the code runs once **per block**. You say \"load tile N\" and cuTile assigns threads to elements inside that block for you\n",
+    "\n",
+    "```\n",
+    "Block 0: load tile 0 → A[0..3]  + B[0..3]   → store to C[0..3]\n",
+    "Block 1: load tile 1 → A[4..7]  + B[4..7]   → store to C[4..7]\n",
+    "Block 2: load tile 2 → A[8..11] + B[8..11]  → store to C[8..11]\n",
+    "```\n",
+    "\n",
+    "cuTile handles the within-block thread assignment and memory access patterns automatically."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "27dce420-dc2f-425b-b199-a93090bbc589",
    "metadata": {},
    "source": [
@@ -138,7 +163,8 @@
     "grid = (ct.cdiv(a_shape, t_shape), 1, 1)\n",
     "ct.launch(cp.cuda.get_current_stream(), grid, vector_add_tile, (A, B, C, t_shape))\n",
     "\n",
-    "cp.testing.assert_array_almost_equal(C, A + B) # Verify the results\n",
+    "cp.testing.assert_array_almost_equal(C, A + B)\n",
+    "print(\"Vector add Tile OK\")\n",
     "\n",
     "threads_per_block = 128\n",
     "items_per_thread = 4\n",
@@ -148,7 +174,8 @@
     "\n",
     "vector_add_simt[thread_blocks, threads_per_block](A, B, C, items_per_thread)\n",
     "\n",
-    "cp.testing.assert_array_almost_equal(C, A + B) # Verify the results"
+    "cp.testing.assert_array_almost_equal(C, A + B)\n",
+    "print(\"Vector add SIMT OK\")"
    ]
   },
   {
@@ -225,7 +252,7 @@
    "id": "a2c6eac7",
    "metadata": {},
    "source": [
-    "Kernel performance often depends on tile sizes and execution parameters, so let's explore the parameter space to make sure our results are reasonable. First, let's tune our tile kernel over the tile size:"
+    "Tile size is a tradeoff: too small and each block barely earns its launch cost, too large and fewer fit on the GPU at once. Let's tune the tile kernel over a range of sizes to find a good value."
    ]
   },
   {
@@ -285,6 +312,14 @@
     "  print(f\"items_per_thread={time['items_per_thread']}, threads_per_block={time['threads_per_block']}, time={time['time']:.3g} s\")\n",
     "\n",
     "print(reduce(lambda x, y: x if x['time'] < y['time'] else y, times))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "324afe60",
+   "metadata": {},
+   "source": [
+    "The key shift from SIMT: you write code once per block, not once per thread. `ct.load` brings a chunk into a tile, you operate on all of it at once, and `ct.store` writes it back. cuTile handles the thread assignment inside the block for you."
    ]
   }
  ],

--- a/tutorials/cuda-tile/notebooks/02__cutile_python__matrix_add.ipynb
+++ b/tutorials/cuda-tile/notebooks/02__cutile_python__matrix_add.ipynb
@@ -1,0 +1,251 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2f64b130",
+   "metadata": {},
+   "source": [
+    "# cuTile Python Tiles: Matrix Add\n",
+    "\n",
+    "In the previous module you added two vectors. The tiles were one-dimensional: each block handled a contiguous run of elements.\n",
+    "\n",
+    "This module extends the same idea to two dimensions using matrix addition. The math is simple on purpose so the focus stays on the tiles.\n",
+    "You will also see how the tile shape you pick affects performance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b08a557f",
+   "metadata": {},
+   "source": [
+    "## Installing cuTile Python\n",
+    "\n",
+    "cuTile Python requires:\n",
+    "\n",
+    "    - NVIDIA Kernel Driver R580 or later.\n",
+    "    - CUDA Toolkit 13.1 or later.\n",
+    "\n",
+    "You can install cuTile Python via the PIP package `cuda-tile`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fca656af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"BREV_ENV_ID\") and not os.path.exists(os.path.expanduser(\"~/.accelerated-computing-hub-installed\")): # If not running in brev\n",
+    "  print(\"Installing PIP packages.\")\n",
+    "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
+    "  !pip install \"cuda-tile\" \"cupy-cuda13x\" > /dev/null 2>&1\n",
+    "  open(os.path.expanduser(\"~/.accelerated-computing-hub-installed\"), \"a\").close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f98bc85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cuda.tile as ct\n",
+    "import cupy as cp\n",
+    "import cupyx as cpx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7999e5c9",
+   "metadata": {},
+   "source": [
+    "## Tiles in Two Dimensions\n",
+    "\n",
+    "A tile does not have to be one-dimensional. Give `shape` two entries and you get a rectangular tile, and `index` then needs two entries too, one per axis.\n",
+    "\n",
+    "A 6x8 array tiled into 3x4 tiles looks like this:\n",
+    "\n",
+    "```\n",
+    "            columns 0-3      columns 4-7\n",
+    "          +---------------+---------------+\n",
+    " rows 0-2 | index=(0, 0)  | index=(0, 1)  |\n",
+    "          +---------------+---------------+\n",
+    " rows 3-5 | index=(1, 0)  | index=(1, 1)  |\n",
+    "          +---------------+---------------+\n",
+    "```\n",
+    "\n",
+    "The rule is the same on each axis independently: tile index `(i, j)` starts at element `(i * 3, j * 4)`.\n",
+    "\n",
+    "To give every tile its own block, we launch a **2D grid**. `ct.bid(0)` is the position along the first grid axis and `ct.bid(1)` along the second. The grid tuple you pass to `ct.launch` is always `(x, y, z)`. For a 1D grid you filled in `(n, 1, 1)`; now we fill in the second slot too."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da88d0bc",
+   "metadata": {},
+   "source": [
+    "## Example: Matrix Add\n",
+    "\n",
+    "Now the kernel. Each block loads one tile from `A`, the matching tile from `B`, adds them, and stores the result in the matching tile of `C`.\n",
+    "\n",
+    "Notice how little changes from the vector add version: the shapes and indices gain a second entry. The grid's second slot, which was `1` in module 01, is now `ct.cdiv(a_shape[1], tn)` because tiles now run along columns too. The addition itself is unchanged, because `+` on tiles is elementwise regardless of how many dimensions the tile has."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3dd59742",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@ct.kernel\n",
+    "def matrix_add_tile(A: ct.Array, B: ct.Array, C: ct.Array,\n",
+    "                    tm: ct.Constant[int],   # tile height, in rows\n",
+    "                    tn: ct.Constant[int]):  # tile width, in columns\n",
+    "  row = ct.bid(0)\n",
+    "  col = ct.bid(1)\n",
+    "\n",
+    "  a_tile = ct.load(A, index=(row, col), shape=(tm, tn))\n",
+    "  b_tile = ct.load(B, index=(row, col), shape=(tm, tn))\n",
+    "\n",
+    "  ct.store(C, index=(row, col), tile=a_tile + b_tile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09775442",
+   "metadata": {},
+   "source": [
+    "Next, let's validate that we've implemented everything correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f03d1f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_shape = (4096, 4096)\n",
+    "t_shape = (64, 64)\n",
+    "\n",
+    "A = cp.random.uniform(-5, 5, a_shape, dtype=cp.float32)\n",
+    "B = cp.random.uniform(-5, 5, a_shape, dtype=cp.float32)\n",
+    "C = cp.zeros_like(A)\n",
+    "\n",
+    "tm, tn = t_shape\n",
+    "grid = (ct.cdiv(a_shape[0], tm), ct.cdiv(a_shape[1], tn), 1)\n",
+    "print(f\"{a_shape[0]}x{a_shape[1]} matrix, {tm}x{tn} tiles, grid = {grid}\")\n",
+    "print(f\"That is {grid[0] * grid[1]:,} tile blocks.\")\n",
+    "\n",
+    "ct.launch(cp.cuda.get_current_stream(), grid, matrix_add_tile, (A, B, C, tm, tn))\n",
+    "\n",
+    "cp.testing.assert_array_almost_equal(C, A + B) # Verify the results\n",
+    "print(\"\\nMatrix add OK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "708953d6",
+   "metadata": {},
+   "source": [
+    "## Choosing a Tile Shape\n",
+    "\n",
+    "A 4096x4096 matrix can be covered by 64x64 tiles, or 128x128 tiles, or 32x256 tiles. All of them are correct. They are not all equally fast.\n",
+    "\n",
+    "In two dimensions, size is not the only thing that matters. The shape of a tile affects performance too. Because rows are stored back to back in memory, a wide tile reads more data in one continuous run than a tall tile holding the same number of elements.\n",
+    "\n",
+    "Kernel performance depends on both tile size and shape, so let's sweep over a few combinations to see what works best."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6834e1c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cuda.core.experimental import Device\n",
+    "\n",
+    "# Same helper as module 01.\n",
+    "def get_peak_memory_bandwidth(device_id: int = 0):\n",
+    "  dev = Device(device_id)\n",
+    "  dev.set_current() # Initialize CUDA for this thread\n",
+    "\n",
+    "  props = dev.properties\n",
+    "  mem_clock_khz = props.memory_clock_rate        # Peak memory clock in kHz.\n",
+    "  bus_width_bits = props.global_memory_bus_width # DRAM bus width in bits.\n",
+    "\n",
+    "  bytes_per_s = (mem_clock_khz * 1_000) * (bus_width_bits / 8) * 2 # DDR factor.\n",
+    "  return bytes_per_s / 2 ** 30\n",
+    "\n",
+    "peak_memory_bandwidth = get_peak_memory_bandwidth(0)\n",
+    "if peak_memory_bandwidth == 0:\n",
+    "  print(\"Note: peak memory bandwidth could not be queried on this device.\")\n",
+    "  print(\"The GB/s column shows real measured throughput.\\n\")\n",
+    "\n",
+    "# Matrix add reads A, reads B, and writes C.\n",
+    "memory_accessed = (3 * A.size * A.dtype.itemsize) / 2 ** 30\n",
+    "print(f\"{memory_accessed:.2f} GB moved, {peak_memory_bandwidth:.1f} GB/s peak memory bandwidth\\n\")\n",
+    "\n",
+    "times = []\n",
+    "for tm, tn in [(16, 16), (32, 32), (64, 64), (128, 128),\n",
+    "               (16, 256), (256, 16), (32, 512)]:\n",
+    "  grid = (ct.cdiv(a_shape[0], tm), ct.cdiv(a_shape[1], tn), 1)\n",
+    "  time = cpx.profiler.benchmark(\n",
+    "    lambda: ct.launch(cp.cuda.get_current_stream(), grid, matrix_add_tile, (A, B, C, tm, tn)),\n",
+    "    (), n_repeat=15, n_warmup=5\n",
+    "  ).gpu_times[0].mean()\n",
+    "\n",
+    "  times.append({'t_shape': (tm, tn), 'time': time})\n",
+    "  bw = memory_accessed / time\n",
+    "  pct = f\"{bw / peak_memory_bandwidth:.2%} of peak\" if peak_memory_bandwidth > 0 else \"n/a (unified memory)\"\n",
+    "  print(f\"tile {tm:>3}x{tn:<3}  {time:.3g} s, {bw:.1f} GB/s, {pct}\")\n",
+    "\n",
+    "from functools import reduce\n",
+    "\n",
+    "print()\n",
+    "print(reduce(lambda x, y: x if x['time'] < y['time'] else y, times))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08981226",
+   "metadata": {},
+   "source": [
+    "Compare 256x16 against 16x256. They hold the same number of elements but usually do not perform the same. The only difference between them is the shape.\n",
+    "\n",
+    "Two things to carry forward: index and shape both gain a second entry when moving from 1D to 2D, and tile shape is a performance knob separate from size."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/cuda-tile/notebooks/03__cutile_python__transpose.ipynb
+++ b/tutorials/cuda-tile/notebooks/03__cutile_python__transpose.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e2e1f700",
+   "metadata": {},
+   "source": [
+    "# cuTile Python: Transpose\n",
+    "\n",
+    "In the previous module you added two matrices using 2D tiles. The kernel loaded tiles from two arrays, computed new values, and stored the results.\n",
+    "\n",
+    "This module introduces a different kind of kernel: one that moves values without computing new ones. Transpose swaps rows and columns. The values stay the same, only their positions change."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84555ff0",
+   "metadata": {},
+   "source": [
+    "## Installing cuTile Python\n",
+    "\n",
+    "cuTile Python requires:\n",
+    "\n",
+    "    - NVIDIA Kernel Driver R580 or later.\n",
+    "    - CUDA Toolkit 13.1 or later.\n",
+    "\n",
+    "You can install cuTile Python via the PIP package `cuda-tile`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2ea05e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"BREV_ENV_ID\") and not os.path.exists(os.path.expanduser(\"~/.accelerated-computing-hub-installed\")): # If not running in brev\n",
+    "  print(\"Installing PIP packages.\")\n",
+    "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
+    "  !pip install \"cuda-tile\" \"cupy-cuda13x\" > /dev/null 2>&1\n",
+    "  open(os.path.expanduser(\"~/.accelerated-computing-hub-installed\"), \"a\").close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89927ceb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cuda.tile as ct\n",
+    "import cupy as cp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "792ed359",
+   "metadata": {},
+   "source": [
+    "## Rearranging Without Computing\n",
+    "\n",
+    "Every kernel so far loaded tiles, computed new values, and stored the results. Transpose is different: the output values are exactly the same as the input. What changes is where they go.\n",
+    "\n",
+    "Element at row `i`, column `j` moves to row `j`, column `i` in the output. A 4x8 matrix becomes an 8x4 matrix.\n",
+    "\n",
+    "Two things change compared to matrix add:\n",
+    "\n",
+    "The output array has its dimensions swapped. An `M x N` input produces an `N x M` output.\n",
+    "\n",
+    "The store index becomes `(col, row)` instead of `(row, col)`, which places the tile in the correct output position. But the elements inside the tile also need to be rearranged. A tile of shape `(tm, tn)` needs to become `(tn, tm)` before it fits there. `ct.transpose(tile)` does that.\n",
+    "\n",
+    "For example, say `IN` is a 4×6 matrix with `tm=2`, `tn=3`:\n",
+    "\n",
+    "```\n",
+    " 1   2   3   4   5   6\n",
+    " 7   8   9  10  11  12\n",
+    "13  14  15  16  17  18\n",
+    "19  20  21  22  23  24\n",
+    "```\n",
+    "\n",
+    "Block `(row=0, col=1)` loads rows 0–1, cols 3–5:\n",
+    "\n",
+    "```\n",
+    " 4   5   6\n",
+    "10  11  12\n",
+    "```\n",
+    "\n",
+    "After `ct.transpose`, the tile becomes a 3×2 block:\n",
+    "\n",
+    "```\n",
+    " 4  10\n",
+    " 5  11\n",
+    " 6  12\n",
+    "```\n",
+    "\n",
+    "It is then stored at index `(col=1, row=0)` in the output, placing it at rows 3–5, cols 0–1 of `OUT`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83b98c3c",
+   "metadata": {},
+   "source": [
+    "## Example: Transpose"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9307346f",
+   "metadata": {},
+   "source": [
+    "Each block handles one `(tm, tn)` tile: it loads the tile at `(row, col)`, transposes it to shape `(tn, tm)` using `ct.transpose`, and writes it to position `(col, row)` in the output. With M=1024 and tm=32, you need 1024/32 = 32 blocks to cover the rows. With N=2048 and tn=64, you need 2048/64 = 32 blocks to cover the columns. The grid is `(32, 32, 1)`, 1024 blocks total."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "029cd903",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@ct.kernel\n",
+    "def transpose(IN: ct.Array, OUT: ct.Array, tm: ct.Constant[int], tn: ct.Constant[int]):\n",
+    "  row = ct.bid(0)\n",
+    "  col = ct.bid(1)\n",
+    "\n",
+    "  tile = ct.load(IN, index=(row, col), shape=(tm, tn))\n",
+    "\n",
+    "  ct.store(OUT, index=(col, row), tile=ct.transpose(tile))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "969bacc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "M, N = 1024, 2048\n",
+    "tm, tn = 32, 64\n",
+    "\n",
+    "IN = cp.random.uniform(-5, 5, (M, N), dtype=cp.float32)\n",
+    "OUT = cp.zeros((N, M), dtype=cp.float32)\n",
+    "\n",
+    "grid = (ct.cdiv(M, tm), ct.cdiv(N, tn), 1)\n",
+    "print(f\"Grid: {grid[0]} × {grid[1]} = {grid[0] * grid[1]:,} blocks\")\n",
+    "\n",
+    "ct.launch(cp.cuda.get_current_stream(), grid, transpose, (IN, OUT, tm, tn))\n",
+    "\n",
+    "cp.testing.assert_array_almost_equal(OUT, IN.T)\n",
+    "print(\"Transpose OK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f74b8361",
+   "metadata": {},
+   "source": [
+    "## Exercise: Symmetric Sum\n",
+    "\n",
+    "A symmetric matrix satisfies `A[i][j] == A[j][i]`. One way to produce a symmetric matrix from any square input is to add it to its own transpose: `OUT = IN + IN.T`.\n",
+    "\n",
+    "Write a kernel that computes this. Each block should load the tile at `(row, col)` and the tile at `(col, row)`, add them with the second tile transposed, and store the result at `(row, col)` in the output.\n",
+    "\n",
+    "Use a square matrix and square tiles so both loads have the same shape.\n",
+    "\n",
+    "Give the exercise a try. A reference solution follows after."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c5d4183",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@ct.kernel\n",
+    "def symmetric_sum(IN: ct.Array, OUT: ct.Array, t: ct.Constant[int]):\n",
+    "  # TODO: load the tile at (row, col) and the tile at (col, row).\n",
+    "  # Add them together, transposing the second one, and store at (row, col).\n",
+    "  pass\n",
+    "\n",
+    "\n",
+    "# N = 1024\n",
+    "# t = 32\n",
+    "# IN = cp.random.uniform(-5, 5, (N, N), dtype=cp.float32)\n",
+    "# OUT = cp.zeros_like(IN)\n",
+    "# grid = (ct.cdiv(N, t), ct.cdiv(N, t), 1)\n",
+    "# ct.launch(cp.cuda.get_current_stream(), grid, symmetric_sum, (IN, OUT, t))\n",
+    "# cp.testing.assert_array_almost_equal(OUT, IN + IN.T)\n",
+    "# print(\"Exercise OK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e3ce9f9",
+   "metadata": {},
+   "source": [
+    "### Solution\n",
+    "\n",
+    "Run the cell below to check your work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61502da3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@ct.kernel\n",
+    "def _symmetric_sum(IN: ct.Array, OUT: ct.Array, t: ct.Constant[int]):\n",
+    "  row = ct.bid(0)\n",
+    "  col = ct.bid(1)\n",
+    "\n",
+    "  tile_a = ct.load(IN, index=(row, col), shape=(t, t))\n",
+    "  tile_b = ct.load(IN, index=(col, row), shape=(t, t))\n",
+    "\n",
+    "  ct.store(OUT, index=(row, col), tile=tile_a + ct.transpose(tile_b))\n",
+    "\n",
+    "\n",
+    "N = 1024\n",
+    "t = 32\n",
+    "\n",
+    "IN = cp.random.uniform(-5, 5, (N, N), dtype=cp.float32)\n",
+    "OUT = cp.zeros_like(IN)\n",
+    "\n",
+    "grid = (ct.cdiv(N, t), ct.cdiv(N, t), 1)\n",
+    "ct.launch(cp.cuda.get_current_stream(), grid, _symmetric_sum, (IN, OUT, t))\n",
+    "\n",
+    "cp.testing.assert_array_almost_equal(OUT, IN + IN.T)\n",
+    "print(\"Exercise OK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7669eb76",
+   "metadata": {},
+   "source": [
+    "Transpose takes exactly two changes: swap the store index to `(col, row)`, and pass the tile through `ct.transpose` before storing. Every element lands in its correct output position."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/cuda-tile/notebooks/04__cutile_python__activation_functions.ipynb
+++ b/tutorials/cuda-tile/notebooks/04__cutile_python__activation_functions.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# cuTile Python: Activation Functions\n",
+    "\n",
+    "The previous modules introduced 2D tiles through matrix addition and transpose. This module uses the same tile structure for activation functions: ReLU and clamp.\n",
+    "\n",
+    "Standard Python operators like `+` and `*` apply elementwise across a tile automatically. For operations that do not have a Python operator equivalent, cuTile provides named functions like `ct.maximum` and `ct.minimum`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "## Installing cuTile Python\n",
+    "\n",
+    "cuTile Python requires:\n",
+    "\n",
+    "    - NVIDIA Kernel Driver R580 or later.\n",
+    "    - CUDA Toolkit 13.1 or later.\n",
+    "\n",
+    "You can install cuTile Python via the PIP package `cuda-tile`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"BREV_ENV_ID\") and not os.path.exists(os.path.expanduser(\"~/.accelerated-computing-hub-installed\")): # If not running in brev\n",
+    "  print(\"Installing PIP packages.\")\n",
+    "  !pip uninstall \"cuda-python\" --yes > /dev/null\n",
+    "  !pip install \"cuda-tile\" \"cupy-cuda13x\" > /dev/null 2>&1\n",
+    "  open(os.path.expanduser(\"~/.accelerated-computing-hub-installed\"), \"a\").close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cuda.tile as ct\n",
+    "import cupy as cp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-5",
+   "metadata": {},
+   "source": [
+    "## Example: ReLU\n",
+    "\n",
+    "ReLU replaces every negative number with zero and leaves positive numbers unchanged:\n",
+    "\n",
+    "$$y = \\max(x,\\; 0)$$\n",
+    "\n",
+    "It is one of the most widely used activation functions in neural networks.\n",
+    "\n",
+    "`ct.maximum(tile, value)` applies a max elementwise across every element in the tile.\n",
+    "Passing `0` sets all negatives to zero in a single call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@ct.kernel\n",
+    "def relu(X: ct.Array, Y: ct.Array, tm: ct.Constant[int], tn: ct.Constant[int]):\n",
+    "  row = ct.bid(0)\n",
+    "  col = ct.bid(1)\n",
+    "\n",
+    "  x_tile = ct.load(X, index=(row, col), shape=(tm, tn))\n",
+    "\n",
+    "  ct.store(Y, index=(row, col), tile=ct.maximum(x_tile, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = cp.random.uniform(-5, 5, (1024, 1024), dtype=cp.float32)\n",
+    "Y = cp.zeros_like(X)\n",
+    "\n",
+    "tm, tn = 64, 64\n",
+    "grid = (ct.cdiv(X.shape[0], tm), ct.cdiv(X.shape[1], tn), 1)\n",
+    "print(f\"Grid: {grid[0]} × {grid[1]} = {grid[0] * grid[1]:,} blocks\")\n",
+    "\n",
+    "ct.launch(cp.cuda.get_current_stream(), grid, relu, (X, Y, tm, tn))\n",
+    "\n",
+    "cp.testing.assert_array_almost_equal(Y, cp.maximum(X, 0))\n",
+    "print(\"ReLU OK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-8",
+   "metadata": {},
+   "source": [
+    "Notice how similar this is to the matrix add kernel from module 02. The load-transform-store structure is identical. The only difference is the operation: `ct.maximum(x_tile, 0)` instead of `a_tile + b_tile`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-9",
+   "metadata": {},
+   "source": [
+    "## Exercise: Clamp\n",
+    "\n",
+    "Clamp limits every value to a range `[lo, hi]`:\n",
+    "\n",
+    "$$y = \\min(\\max(x,\\; lo),\\; hi)$$\n",
+    "\n",
+    "It is used in gradient clipping and quantization.\n",
+    "`ct.minimum(tile, value)` works the same way as `ct.maximum` but applies a min instead of a max.\n",
+    "\n",
+    "Write a kernel that clamps a matrix to `[-1.0, 1.0]`.\n",
+    "\n",
+    "Give the exercise a try. A reference solution follows after."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@ct.kernel\n",
+    "def clamp(X: ct.Array, Y: ct.Array, tm: ct.Constant[int], tn: ct.Constant[int]):\n",
+    "  # TODO: your code here.\n",
+    "  # Hint: nest ct.minimum and ct.maximum.\n",
+    "  pass\n",
+    "\n",
+    "\n",
+    "# X2 = cp.random.uniform(-10, 10, (1024, 1024), dtype=cp.float32)\n",
+    "# Y2 = cp.zeros_like(X2)\n",
+    "# tm, tn = 64, 64\n",
+    "# grid = (ct.cdiv(X2.shape[0], tm), ct.cdiv(X2.shape[1], tn), 1)\n",
+    "# ct.launch(cp.cuda.get_current_stream(), grid, clamp, (X2, Y2, tm, tn))\n",
+    "# cp.testing.assert_array_almost_equal(Y2, cp.clip(X2, -1.0, 1.0))\n",
+    "# print(\"Exercise OK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8036039d",
+   "metadata": {},
+   "source": [
+    "### Solution\n",
+    "\n",
+    "Run the cell below to check your work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@ct.kernel\n",
+    "def _clamp(X: ct.Array, Y: ct.Array, tm: ct.Constant[int], tn: ct.Constant[int]):\n",
+    "  row = ct.bid(0)\n",
+    "  col = ct.bid(1)\n",
+    "\n",
+    "  x_tile = ct.load(X, index=(row, col), shape=(tm, tn))\n",
+    "\n",
+    "  ct.store(Y, index=(row, col), tile=ct.minimum(ct.maximum(x_tile, -1.0), 1.0))\n",
+    "\n",
+    "\n",
+    "X2 = cp.random.uniform(-10, 10, (1024, 1024), dtype=cp.float32)\n",
+    "Y2 = cp.zeros_like(X2)\n",
+    "\n",
+    "tm, tn = 64, 64\n",
+    "grid = (ct.cdiv(X2.shape[0], tm), ct.cdiv(X2.shape[1], tn), 1)\n",
+    "ct.launch(cp.cuda.get_current_stream(), grid, _clamp, (X2, Y2, tm, tn))\n",
+    "\n",
+    "cp.testing.assert_array_almost_equal(Y2, cp.clip(X2, -1.0, 1.0))\n",
+    "print(\"Exercise OK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-13",
+   "metadata": {},
+   "source": [
+    "ReLU and clamp use named cuTile operations: `ct.maximum` and `ct.minimum`. For the full list, see the [operations reference](https://docs.nvidia.com/cuda/cutile-python/operations.html)."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/cuda-tile/notebooks/start.ipynb
+++ b/tutorials/cuda-tile/notebooks/start.ipynb
@@ -15,7 +15,10 @@
     "\n",
     "| # | Topic | Solution | Technologies | \n",
     "|---|-------|----------|--------------|\n",
-    "| 01 | [cuTile Python Intro](01__cutile_python_intro__vector_add.ipynb) | - | cuTile Python |\n"
+    "| 01 | [cuTile Python Intro](01__cutile_python_intro__vector_add.ipynb) | - | cuTile Python |\n",
+    "| 02 | [cuTile Python: Matrix Add](02__cutile_python__matrix_add.ipynb) | - | cuTile Python |\n",
+    "| 03 | [cuTile Python: Transpose](03__cutile_python__transpose.ipynb) | - | cuTile Python |\n",
+    "| 04 | [cuTile Python: Activation Functions](04__cutile_python__activation_functions.ipynb) | - | cuTile Python |"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

- Add three new cuTile Python tutorial notebooks: matrix add (02), transpose (03), and activation functions (04)
- Improve notebook 01 with a tile-vs-SIMT explanation and validation print statements
- Update README.md and start.ipynb to include the new notebook entries

## Notebooks

**01 - Vector Add (updated):** Added an inline explanation of the tile-vs-SIMT programming model shift and print statements after each validation assertion.

**02 - Matrix Add (new):** Introduces 2D tiles and shows how the grid covers a matrix with both row and column dimensions.

**03 - Transpose (new):** Covers transposing a tile with `ct.transpose()` and swapping the store index. Includes a symmetric sum exercise with an inline solution.

**04 - Activation Functions (new):** Covers `ct.maximum` and `ct.minimum` as named cuTile operations via ReLU and clamp kernels. Includes a clamp exercise with an inline solution.

## Notes

The pre-push hook reports format failures on three pre-existing notebooks that I did not modify:
- `events/gtc_spring_2025/talks/cuda_techniques_compute_and_instruction_S72685/line_intersection/jupyter/line_intersection.ipynb`
- `events/pycon_2025/ai_with_a_conscience.ipynb`
- `docs/notebook_template.ipynb`

These failures exist on `main` independently of this PR.