### PR TITLE
Fix ModuleNotFoundError for jupyter-dark-detect on Google Colab.

### DIFF
--- a/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/01.04.01-Vocabulary-Types.ipynb
+++ b/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/01.04.01-Vocabulary-Types.ipynb
@@ -30,6 +30,7 @@
     "import os\n",
     "\n",
     "if os.getenv(\"COLAB_RELEASE_TAG\"): # If running in Google Colab:\n",
+    "  !pip install -q jupyter-dark-detect\n",
     "  !mkdir -p Sources\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/Sources/ach.h -nv -O Sources/ach.h\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/Sources/ach.py -nv -O Sources/ach.py\n",

--- a/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/01.04.02-Exercise-mdspan.ipynb
+++ b/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/01.04.02-Exercise-mdspan.ipynb
@@ -86,6 +86,7 @@
     "import os\n",
     "\n",
     "if os.getenv(\"COLAB_RELEASE_TAG\"): # If running in Google Colab:\n",
+    "  !pip install -q jupyter-dark-detect\n",
     "  !mkdir -p Sources\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/Sources/ach.h -nv -O Sources/ach.h\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/Sources/ach.py -nv -O Sources/ach.py\n",

--- a/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/Sources/ach.py
+++ b/tutorials/cuda-cpp/notebooks/01.04-Vocabulary-Types/Sources/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 plt.style.use('dark_background' if is_dark() else 'default')

--- a/tutorials/cuda-cpp/notebooks/02.02-Asynchrony/Sources/ach.py
+++ b/tutorials/cuda-cpp/notebooks/02.02-Asynchrony/Sources/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 plt.style.use('dark_background' if is_dark() else 'default')

--- a/tutorials/cuda-cpp/notebooks/02.03-Streams/Sources/ach.py
+++ b/tutorials/cuda-cpp/notebooks/02.03-Streams/Sources/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 plt.style.use('dark_background' if is_dark() else 'default')

--- a/tutorials/cuda-cpp/notebooks/02.04-Pinned-Memory/Sources/ach.py
+++ b/tutorials/cuda-cpp/notebooks/02.04-Pinned-Memory/Sources/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 plt.style.use('dark_background' if is_dark() else 'default')

--- a/tutorials/cuda-cpp/notebooks/03.03-Atomics/03.03.01-Histogram.ipynb
+++ b/tutorials/cuda-cpp/notebooks/03.03-Atomics/03.03.01-Histogram.ipynb
@@ -57,6 +57,7 @@
     "import os\n",
     "\n",
     "if os.getenv(\"COLAB_RELEASE_TAG\"): # If running in Google Colab:\n",
+    "  !pip install -q jupyter-dark-detect\n",
     "  !mkdir -p Sources\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.03-Atomics/Sources/ach.cuh -nv -O Sources/ach.cuh\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.03-Atomics/Sources/__init__.py -nv -O Sources/__init__.py\n",

--- a/tutorials/cuda-cpp/notebooks/03.03-Atomics/03.03.02-Exercise-Fix-Histogram.ipynb
+++ b/tutorials/cuda-cpp/notebooks/03.03-Atomics/03.03.02-Exercise-Fix-Histogram.ipynb
@@ -38,6 +38,7 @@
     "import os\n",
     "\n",
     "if os.getenv(\"COLAB_RELEASE_TAG\"): # If running in Google Colab:\n",
+    "  !pip install -q jupyter-dark-detect\n",
     "  !mkdir -p Sources\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.03-Atomics/Sources/ach.cuh -nv -O Sources/ach.cuh\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.03-Atomics/Sources/__init__.py -nv -O Sources/__init__.py\n",

--- a/tutorials/cuda-cpp/notebooks/03.03-Atomics/Sources/ach.py
+++ b/tutorials/cuda-cpp/notebooks/03.03-Atomics/Sources/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 from matplotlib.ticker import StrMethodFormatter
 import matplotlib.animation as animation

--- a/tutorials/cuda-cpp/notebooks/03.04-Synchronization/03.04.01-Sync.ipynb
+++ b/tutorials/cuda-cpp/notebooks/03.04-Synchronization/03.04.01-Sync.ipynb
@@ -74,6 +74,7 @@
     "import os\n",
     "\n",
     "if os.getenv(\"COLAB_RELEASE_TAG\"): # If running in Google Colab:\n",
+    "  !pip install -q jupyter-dark-detect\n",
     "  !mkdir -p Sources\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.04-Synchronization/Sources/ach.cuh -nv -O Sources/ach.cuh\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.04-Synchronization/Sources/__init__.py -nv -O Sources/__init__.py\n",

--- a/tutorials/cuda-cpp/notebooks/03.04-Synchronization/03.04.02-Exercise-Histogram.ipynb
+++ b/tutorials/cuda-cpp/notebooks/03.04-Synchronization/03.04.02-Exercise-Histogram.ipynb
@@ -81,6 +81,7 @@
     "import os\n",
     "\n",
     "if os.getenv(\"COLAB_RELEASE_TAG\"): # If running in Google Colab:\n",
+    "  !pip install -q jupyter-dark-detect\n",
     "  !mkdir -p Sources\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.04-Synchronization/Sources/ach.cuh -nv -O Sources/ach.cuh\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.04-Synchronization/Sources/__init__.py -nv -O Sources/__init__.py\n",

--- a/tutorials/cuda-cpp/notebooks/03.04-Synchronization/Solutions/ach.py
+++ b/tutorials/cuda-cpp/notebooks/03.04-Synchronization/Solutions/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 from matplotlib.ticker import StrMethodFormatter
 import matplotlib.animation as animation

--- a/tutorials/cuda-cpp/notebooks/03.04-Synchronization/Sources/ach.py
+++ b/tutorials/cuda-cpp/notebooks/03.04-Synchronization/Sources/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 from matplotlib.ticker import StrMethodFormatter
 import matplotlib.animation as animation

--- a/tutorials/cuda-cpp/notebooks/03.05-Shared-Memory/03.05.02-Exercise-Optimize-Histogram.ipynb
+++ b/tutorials/cuda-cpp/notebooks/03.05-Shared-Memory/03.05.02-Exercise-Optimize-Histogram.ipynb
@@ -80,6 +80,7 @@
     "import os\n",
     "\n",
     "if os.getenv(\"COLAB_RELEASE_TAG\"): # If running in Google Colab:\n",
+    "  !pip install -q jupyter-dark-detect\n",
     "  !mkdir -p Sources\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.05-Shared-Memory/Sources/ach.cuh -nv -O Sources/ach.cuh\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.05-Shared-Memory/Sources/__init__.py -nv -O Sources/__init__.py\n",

--- a/tutorials/cuda-cpp/notebooks/03.05-Shared-Memory/Solutions/ach.py
+++ b/tutorials/cuda-cpp/notebooks/03.05-Shared-Memory/Solutions/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 from matplotlib.ticker import StrMethodFormatter
 import matplotlib.animation as animation

--- a/tutorials/cuda-cpp/notebooks/03.05-Shared-Memory/Sources/ach.py
+++ b/tutorials/cuda-cpp/notebooks/03.05-Shared-Memory/Sources/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 from matplotlib.ticker import StrMethodFormatter
 import matplotlib.animation as animation

--- a/tutorials/cuda-cpp/notebooks/03.06-Cooperative-Algorithms/03.06.02-Exercise-Cooperative-Histogram.ipynb
+++ b/tutorials/cuda-cpp/notebooks/03.06-Cooperative-Algorithms/03.06.02-Exercise-Cooperative-Histogram.ipynb
@@ -56,6 +56,7 @@
     "import os\n",
     "\n",
     "if os.getenv(\"COLAB_RELEASE_TAG\"): # If running in Google Colab:\n",
+    "  !pip install -q jupyter-dark-detect\n",
     "  !mkdir -p Sources\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.06-Cooperative-Algorithms/Sources/ach.cuh -nv -O Sources/ach.cuh\n",
     "  !wget https://raw.githubusercontent.com/NVIDIA/accelerated-computing-hub/refs/heads/main/tutorials/cuda-cpp/notebooks/03.06-Cooperative-Algorithms/Sources/__init__.py -nv -O Sources/__init__.py\n",

--- a/tutorials/cuda-cpp/notebooks/03.06-Cooperative-Algorithms/Sources/ach.py
+++ b/tutorials/cuda-cpp/notebooks/03.06-Cooperative-Algorithms/Sources/ach.py
@@ -3,7 +3,12 @@ from IPython.display import HTML
 import numpy as np
 import glob
 import os
-from jupyter_dark_detect import is_dark
+try:
+    from jupyter_dark_detect import is_dark
+except ImportError:
+    # Optional theming dependency; assume a light theme when unavailable.
+    def is_dark():
+        return False
 import matplotlib.pyplot as plt
 from matplotlib.ticker import StrMethodFormatter
 import matplotlib.animation as animation


### PR DESCRIPTION
PR #153 added `jupyter-dark-detect` to the tutorial `requirements.txt` files, which provision the Brev containers. The Colab bootstrap cells are a separate path that never reads those files, so `import Sources.ach` fails on Colab. The import is at module scope, so this breaks every cell that renders a plot or animation, not just the theming. First observed in 01.04.02, opened from the Colab badge in tutorials/cuda-cpp/README.md.

Install the package in the eight Colab bootstrap cells that fetch `ach.py`, and make the import non-fatal in all ten copies of `ach.py`. `is_dark()` already returns False when detection fails, so assuming a light theme when the package is absent matches its existing behavior.