### PR TITLE
Chapter 9 cuGraph: update install pins and add CUDA library preload

### DIFF
--- a/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
@@ -90,9 +90,12 @@
    },
    "outputs": [],
    "source": [
+    "# Install a cudf / cugraph build that matches this environment's CUDA and Python.\n",
+    "# The 24.10 pin in the original notebook is far too old (no wheels for recent\n",
+    "# Python); use a current RAPIDS release instead.\n",
     "!pip install \\\n",
     "    --extra-index-url=https://pypi.nvidia.com \\\n",
-    "    cudf-cu12==24.10.* cugraph-cu12==24.10.* "
+    "    \"cudf-cu12==26.8.*\" \"cugraph-cu12==26.8.*\""
    ]
   },
   {
@@ -151,6 +154,39 @@
     "Node 0 connects to Node 2\n",
     "Node 1 connects to Node 2\n",
     "Node 2 connects back to Node 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b629fc39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Environment workaround -------------------------------------------------\n",
+    "# Some RAPIDS pip wheels ship their CUDA math libraries (libnvrtc, cuBLAS, ...)\n",
+    "# inside `nvidia/*` packages but don't always register them with the dynamic\n",
+    "# loader before cuGraph's compiled extensions are imported. That shows up as\n",
+    "# `ImportError: libnvrtc.so.12: cannot open shared object file`.\n",
+    "# Pre-loading those libraries into the global symbol namespace fixes it.\n",
+    "# This is a no-op on a correctly configured environment.\n",
+    "import ctypes, glob, os, sysconfig\n",
+    "\n",
+    "_sp = sysconfig.get_paths()[\"purelib\"]\n",
+    "_lib_dirs = [\n",
+    "    \"nvidia/cuda_nvrtc/lib\", \"nvidia/nvjitlink/lib\", \"nvidia/cublas/lib\",\n",
+    "    \"nvidia/cusparse/lib\", \"nvidia/cusolver/lib\", \"nvidia/curand/lib\",\n",
+    "    \"nvidia/cufft/lib\",\n",
+    "]\n",
+    "for _rel in _lib_dirs:\n",
+    "    for _so in sorted(glob.glob(os.path.join(_sp, _rel, \"*.so*\"))):\n",
+    "        try:\n",
+    "            ctypes.CDLL(_so, mode=ctypes.RTLD_GLOBAL)\n",
+    "        except OSError:\n",
+    "            pass\n",
+    "\n",
+    "import cugraph\n",
+    "print(\"cugraph\", cugraph.__version__)"
    ]
   },
   {
@@ -307,7 +343,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nx-cugraph-cu12 --extra-index-url=https://pypi.nvidia.com"
+    "!pip install \"nx-cugraph-cu12==26.8.*\" --extra-index-url=https://pypi.nvidia.com"
    ]
   },
   {


### PR DESCRIPTION
### Problem
- The notebook pins `cudf-cu12` and `cugraph-cu12` to `24.10.*`, which has no
  wheels for current Python versions, so the install cell fails.
- `nx-cugraph-cu12` is installed unpinned, so it can resolve to a version out
  of step with the rest of RAPIDS.
- On pip wheel installs, importing `cugraph` can fail with
  `ImportError: libnvrtc.so.12: cannot open shared object file` because the
  CUDA math libraries shipped in the `nvidia/*` packages are not always
  registered with the dynamic loader first.

### Changes
- Pin `cudf-cu12` and `cugraph-cu12` to `26.8.*`, and pin `nx-cugraph-cu12`
  to `26.8.*`.
- Add a cell that pre-loads the RAPIDS `nvidia/*` CUDA math libraries with
  `RTLD_GLOBAL` before `import cugraph`. It is a no-op on a correctly
  configured environment.
