### PR TITLE
Chapter 9 cuGraph: fix PageRank example bugs and undersized benchmark

### DIFF
--- a/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
@@ -209,8 +209,9 @@
     "    'dst': [1, 2, 2, 0]\n",
     "})\n",
     "\n",
-    "# Create the graph\n",
-    "G = cugraph.Graph()\n",
+    "# Create the graph. The edge list is directed (note the 2 -> 0 \"connects back\"\n",
+    "# edge), so build a directed Graph.\n",
+    "G = cugraph.Graph(directed=True)\n",
     "G.from_cudf_edgelist(edge_list, source='src', destination='dst')"
    ]
   },
@@ -310,16 +311,21 @@
    },
    "outputs": [],
    "source": [
-    "# Perform PageRank on the weighted graph\n",
+    "# Perform PageRank on the graph we built above\n",
     "pagerank_result = cugraph.pagerank(G)\n",
     "\n",
     "# Display the PageRank values\n",
     "print(pagerank_result)\n",
     "\n",
-    "G = karate.get_graph(download=True)\n",
+    "# Now try it on a larger, real-world graph: Zachary's Karate Club, which ships\n",
+    "# with cuGraph as a sample dataset.\n",
+    "from cugraph.datasets import karate\n",
+    "\n",
+    "karate_G = karate.get_graph(download=True)\n",
     "\n",
     "# Call cugraph.pagerank to get the pagerank scores\n",
-    "gdf_page = cugraph.pagerank(G)\n"
+    "gdf_page = cugraph.pagerank(karate_G)\n",
+    "print(gdf_page.sort_values('pagerank', ascending=False).head())"
    ]
   },
   {
@@ -384,7 +390,8 @@
    },
    "outputs": [],
    "source": [
-    "G = nx.gnm_random_graph(5000, 40000)\n",
+    "# A graph big enough that the GPU backend has something to chew on.\n",
+    "G = nx.gnm_random_graph(200_000, 2_000_000)\n",
     "\n",
     "import time \n",
     "start_time = time.time()\n",
@@ -417,12 +424,12 @@
     "import networkx as nx\n",
     "print(f\"using networkx version {nx.__version__}\")\n",
     "\n",
-    "#nx.config.warnings_to_ignore.add(\"cache\")\n",
-    "\n",
-    "\n",
-    "import time \n",
+    "# NetworkX is already imported above, so the autoconfig env var alone won't\n",
+    "# switch backends inside this kernel. Ask for the cuGraph backend explicitly to\n",
+    "# run the exact same call on the GPU.\n",
+    "import time\n",
     "start_time = time.time()\n",
-    "pr = nx.pagerank(G)\n",
+    "pr = nx.pagerank(G, backend=\"cugraph\")\n",
     "elapsed_time = time.time() - start_time\n",
     "print(elapsed_time)"
    ]

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
@@ -90,9 +90,12 @@
    },
    "outputs": [],
    "source": [
+    "# Install a cudf / cugraph build that matches this environment's CUDA and Python.\n",
+    "# The 24.10 pin in the original notebook is far too old (no wheels for recent\n",
+    "# Python); use a current RAPIDS release instead.\n",
     "!pip install \\\n",
     "    --extra-index-url=https://pypi.nvidia.com \\\n",
-    "    cudf-cu12==24.10.* cugraph-cu12==24.10.* "
+    "    \"cudf-cu12==26.8.*\" \"cugraph-cu12==26.8.*\""
    ]
   },
   {
@@ -151,6 +154,39 @@
     "Node 0 connects to Node 2\n",
     "Node 1 connects to Node 2\n",
     "Node 2 connects back to Node 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b629fc39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Environment workaround -------------------------------------------------\n",
+    "# Some RAPIDS pip wheels ship their CUDA math libraries (libnvrtc, cuBLAS, ...)\n",
+    "# inside `nvidia/*` packages but don't always register them with the dynamic\n",
+    "# loader before cuGraph's compiled extensions are imported. That shows up as\n",
+    "# `ImportError: libnvrtc.so.12: cannot open shared object file`.\n",
+    "# Pre-loading those libraries into the global symbol namespace fixes it.\n",
+    "# This is a no-op on a correctly configured environment.\n",
+    "import ctypes, glob, os, sysconfig\n",
+    "\n",
+    "_sp = sysconfig.get_paths()[\"purelib\"]\n",
+    "_lib_dirs = [\n",
+    "    \"nvidia/cuda_nvrtc/lib\", \"nvidia/nvjitlink/lib\", \"nvidia/cublas/lib\",\n",
+    "    \"nvidia/cusparse/lib\", \"nvidia/cusolver/lib\", \"nvidia/curand/lib\",\n",
+    "    \"nvidia/cufft/lib\",\n",
+    "]\n",
+    "for _rel in _lib_dirs:\n",
+    "    for _so in sorted(glob.glob(os.path.join(_sp, _rel, \"*.so*\"))):\n",
+    "        try:\n",
+    "            ctypes.CDLL(_so, mode=ctypes.RTLD_GLOBAL)\n",
+    "        except OSError:\n",
+    "            pass\n",
+    "\n",
+    "import cugraph\n",
+    "print(\"cugraph\", cugraph.__version__)"
    ]
   },
   {
@@ -307,7 +343,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nx-cugraph-cu12 --extra-index-url=https://pypi.nvidia.com"
+    "!pip install \"nx-cugraph-cu12==26.8.*\" --extra-index-url=https://pypi.nvidia.com"
    ]
   },
   {


### PR DESCRIPTION
Builds on #257.

### Problem
- The first example builds `cugraph.Graph()` (undirected) even though the
  edge list has a `2 -> 0` "connects back" edge and is meant to be directed.
- The PageRank cell calls `karate.get_graph(...)` without importing `karate`,
  and assigns the result to `G`, overwriting the small example graph.
- The NetworkX-vs-cuGraph benchmark uses a 5,000 node / 40,000 edge random
  graph, too small to show a backend difference.
- Setting `NX_CUGRAPH_AUTOCONFIG` after NetworkX is already imported does not
  switch the backend, so the "GPU" cell still runs on CPU.

### Changes
- Build the first graph with `cugraph.Graph(directed=True)`.
- Import `karate` from `cugraph.datasets`, store the graph in `karate_G`, and
  print the top PageRank rows.
- Grow the random graph to 200,000 nodes / 2,000,000 edges.
- Call `nx.pagerank(G, backend="cugraph")` explicitly.
