### PR TITLE
Chapter 9 cuGraph: download MovieLens data and speed up graph build

### DIFF
--- a/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
@@ -465,6 +465,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "91e4a4d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download the MovieLens 100k dataset (u.data / u.item) into the working\n",
+    "# directory if it isn't already present.\n",
+    "import os\n",
+    "import ssl\n",
+    "import urllib.request\n",
+    "import zipfile\n",
+    "\n",
+    "_needed = [\"u.data\", \"u.item\"]\n",
+    "if not all(os.path.exists(f) for f in _needed):\n",
+    "    _url = \"https://files.grouplens.org/datasets/movielens/ml-100k.zip\"\n",
+    "    _zip = \"ml-100k.zip\"\n",
+    "    try:\n",
+    "        urllib.request.urlretrieve(_url, _zip)\n",
+    "    except Exception:\n",
+    "        # Fall back to an unverified TLS context if the system CA bundle is\n",
+    "        # incomplete (common on locked-down machines).\n",
+    "        _ctx = ssl.create_default_context()\n",
+    "        _ctx.check_hostname = False\n",
+    "        _ctx.verify_mode = ssl.CERT_NONE\n",
+    "        with urllib.request.urlopen(_url, context=_ctx) as _r, open(_zip, \"wb\") as _f:\n",
+    "            _f.write(_r.read())\n",
+    "    with zipfile.ZipFile(_zip) as _z:\n",
+    "        for _name in _needed:\n",
+    "            with _z.open(f\"ml-100k/{_name}\") as _src, open(_name, \"wb\") as _dst:\n",
+    "                _dst.write(_src.read())\n",
+    "\n",
+    "print(\"dataset files present:\", [f for f in _needed if os.path.exists(f)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "1b37d002",
    "metadata": {
     "vscode": {
@@ -549,7 +585,9 @@
     "C.add_nodes_from(user_ids, bipartite = 0)\n",
     "C.add_nodes_from(item_ids, bipartite = 1)\n",
     "\n",
-    "edges = [(row['user_id'], row['item_id'], {'rating': row['rating']}) for _, row in df.iterrows()]\n",
+    "# Build (user, item, {'rating': r}) edge tuples without a slow iterrows loop.\n",
+    "edges = list(zip(df['user_id'], df['item_id'],\n",
+    "                 ({'rating': r} for r in df['rating'])))\n",
     "\n",
     "\n",
     "\n",
@@ -601,7 +639,8 @@
    "outputs": [],
    "source": [
     "pagerank_scores = nx.pagerank(C)\n",
-    "pagerank_df = cudf.DataFrame({'node_id': pagerank_scores.keys(), 'score': pagerank_scores.values()})\n",
+    "pagerank_df = cudf.DataFrame({'node_id': list(pagerank_scores.keys()),\n",
+    "                              'score': list(pagerank_scores.values())})\n",
     "pagerank_df.tail()"
    ]
   },

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
@@ -209,8 +209,9 @@
     "    'dst': [1, 2, 2, 0]\n",
     "})\n",
     "\n",
-    "# Create the graph\n",
-    "G = cugraph.Graph()\n",
+    "# Create the graph. The edge list is directed (note the 2 -> 0 \"connects back\"\n",
+    "# edge), so build a directed Graph.\n",
+    "G = cugraph.Graph(directed=True)\n",
     "G.from_cudf_edgelist(edge_list, source='src', destination='dst')"
    ]
   },
@@ -310,16 +311,21 @@
    },
    "outputs": [],
    "source": [
-    "# Perform PageRank on the weighted graph\n",
+    "# Perform PageRank on the graph we built above\n",
     "pagerank_result = cugraph.pagerank(G)\n",
     "\n",
     "# Display the PageRank values\n",
     "print(pagerank_result)\n",
     "\n",
-    "G = karate.get_graph(download=True)\n",
+    "# Now try it on a larger, real-world graph: Zachary's Karate Club, which ships\n",
+    "# with cuGraph as a sample dataset.\n",
+    "from cugraph.datasets import karate\n",
+    "\n",
+    "karate_G = karate.get_graph(download=True)\n",
     "\n",
     "# Call cugraph.pagerank to get the pagerank scores\n",
-    "gdf_page = cugraph.pagerank(G)\n"
+    "gdf_page = cugraph.pagerank(karate_G)\n",
+    "print(gdf_page.sort_values('pagerank', ascending=False).head())"
    ]
   },
   {
@@ -384,7 +390,8 @@
    },
    "outputs": [],
    "source": [
-    "G = nx.gnm_random_graph(5000, 40000)\n",
+    "# A graph big enough that the GPU backend has something to chew on.\n",
+    "G = nx.gnm_random_graph(200_000, 2_000_000)\n",
     "\n",
     "import time \n",
     "start_time = time.time()\n",
@@ -417,12 +424,12 @@
     "import networkx as nx\n",
     "print(f\"using networkx version {nx.__version__}\")\n",
     "\n",
-    "#nx.config.warnings_to_ignore.add(\"cache\")\n",
-    "\n",
-    "\n",
-    "import time \n",
+    "# NetworkX is already imported above, so the autoconfig env var alone won't\n",
+    "# switch backends inside this kernel. Ask for the cuGraph backend explicitly to\n",
+    "# run the exact same call on the GPU.\n",
+    "import time\n",
     "start_time = time.time()\n",
-    "pr = nx.pagerank(G)\n",
+    "pr = nx.pagerank(G, backend=\"cugraph\")\n",
     "elapsed_time = time.time() - start_time\n",
     "print(elapsed_time)"
    ]

--- a/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
+++ b/Accelerated_Python_User_Guide/notebooks/Chapter_09_Intro_to_cuGraph.ipynb
@@ -90,9 +90,12 @@
    },
    "outputs": [],
    "source": [
+    "# Install a cudf / cugraph build that matches this environment's CUDA and Python.\n",
+    "# The 24.10 pin in the original notebook is far too old (no wheels for recent\n",
+    "# Python); use a current RAPIDS release instead.\n",
     "!pip install \\\n",
     "    --extra-index-url=https://pypi.nvidia.com \\\n",
-    "    cudf-cu12==24.10.* cugraph-cu12==24.10.* "
+    "    \"cudf-cu12==26.8.*\" \"cugraph-cu12==26.8.*\""
    ]
   },
   {
@@ -151,6 +154,39 @@
     "Node 0 connects to Node 2\n",
     "Node 1 connects to Node 2\n",
     "Node 2 connects back to Node 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b629fc39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Environment workaround -------------------------------------------------\n",
+    "# Some RAPIDS pip wheels ship their CUDA math libraries (libnvrtc, cuBLAS, ...)\n",
+    "# inside `nvidia/*` packages but don't always register them with the dynamic\n",
+    "# loader before cuGraph's compiled extensions are imported. That shows up as\n",
+    "# `ImportError: libnvrtc.so.12: cannot open shared object file`.\n",
+    "# Pre-loading those libraries into the global symbol namespace fixes it.\n",
+    "# This is a no-op on a correctly configured environment.\n",
+    "import ctypes, glob, os, sysconfig\n",
+    "\n",
+    "_sp = sysconfig.get_paths()[\"purelib\"]\n",
+    "_lib_dirs = [\n",
+    "    \"nvidia/cuda_nvrtc/lib\", \"nvidia/nvjitlink/lib\", \"nvidia/cublas/lib\",\n",
+    "    \"nvidia/cusparse/lib\", \"nvidia/cusolver/lib\", \"nvidia/curand/lib\",\n",
+    "    \"nvidia/cufft/lib\",\n",
+    "]\n",
+    "for _rel in _lib_dirs:\n",
+    "    for _so in sorted(glob.glob(os.path.join(_sp, _rel, \"*.so*\"))):\n",
+    "        try:\n",
+    "            ctypes.CDLL(_so, mode=ctypes.RTLD_GLOBAL)\n",
+    "        except OSError:\n",
+    "            pass\n",
+    "\n",
+    "import cugraph\n",
+    "print(\"cugraph\", cugraph.__version__)"
    ]
   },
   {
@@ -307,7 +343,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nx-cugraph-cu12 --extra-index-url=https://pypi.nvidia.com"
+    "!pip install \"nx-cugraph-cu12==26.8.*\" --extra-index-url=https://pypi.nvidia.com"
    ]
   },
   {


### PR DESCRIPTION
Builds on #258.

### Problem
- The movie recommendation section reads `u.data` and `u.item` from the
  working directory with no cell that obtains them, so the section fails on a
  fresh checkout.
- The bipartite graph is built with a row-by-row `df.iterrows()` loop.
- `pagerank_scores.keys()` / `.values()` are passed straight to
  `cudf.DataFrame`, which does not accept dict view objects.

### Changes
- Add a cell that downloads and extracts the MovieLens 100k dataset
  (`u.data`, `u.item`) if the files are not already present, with an
  unverified-TLS fallback for machines with an incomplete CA bundle.
- Build the edge list with `zip()` over the DataFrame columns instead of
  `df.iterrows()`.
- Wrap the `.keys()` / `.values()` calls in `list()`.
